### PR TITLE
Task 13: Creating Update palette + Upgrades

### DIFF
--- a/cmd/generate/entry.go
+++ b/cmd/generate/entry.go
@@ -2,7 +2,6 @@ package generate
 
 import (
 	"bufio"
-	"database/sql"
 	"fmt"
 	database "github.com/Keith1039/dbvg/db"
 	"github.com/Keith1039/dbvg/parameters"
@@ -37,13 +36,9 @@ var entryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		var writer *parameters.QueryWriter
-		db, err := InitDB()
-		defer func(db *sql.DB) {
-			err := db.Close()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}(db)
+		db, err := database.InitDB(ConnString) // starts up database connection
+		defer database.CloseDB(db)             // closes the database connection
+
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -4,7 +4,6 @@
 package generate
 
 import (
-	"database/sql"
 	"github.com/spf13/cobra"
 	"log"
 )
@@ -47,13 +46,4 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// generateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
-
-// InitDB initiates the database and returns it
-func InitDB() (*sql.DB, error) {
-	db, err := sql.Open("postgres", ConnString)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return db, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 
 import (
 	"github.com/Keith1039/dbvg/cmd/generate"
+	"github.com/Keith1039/dbvg/cmd/update"
 	"github.com/Keith1039/dbvg/cmd/validate"
 	"os"
 
@@ -35,6 +36,7 @@ func Execute() {
 func addSubCommandPalettes() {
 	rootCmd.AddCommand(validate.ValidateCmd)
 	rootCmd.AddCommand(generate.GenerateCmd)
+	rootCmd.AddCommand(update.UpdateCmd)
 }
 
 func init() {

--- a/cmd/update/template.go
+++ b/cmd/update/template.go
@@ -1,0 +1,130 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	database "github.com/Keith1039/dbvg/db"
+	"github.com/Keith1039/dbvg/graph"
+	"github.com/Keith1039/dbvg/utils"
+	"github.com/spf13/cobra"
+	"log"
+	"os"
+)
+
+var (
+	templatePath string
+	tableName    string
+)
+
+// updateCmd represents the update command
+var templateCmd = &cobra.Command{
+	Use:   "template",
+	Short: "Command that updates an existing template",
+	Long: `Command that updates an existing template. The command verifies for corruption before overwriting the current template with the new one.
+This command also maps entries from the old template over to the new template.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// check to see if file exists
+		if _, err := os.Stat(templatePath); !os.IsNotExist(err) {
+			db, err := database.InitDB(ConnString) // start up the database
+			defer database.CloseDB(db)             // close the database connection
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			oldTemplate, err := verifyTemplate(templatePath) // verify that the old template is a valid template and return information
+			if err != nil {
+				log.Fatal(err)
+			}
+			ord := graph.NewOrdering(db)               // get a new ordering
+			tableOrder, err := ord.GetOrder(tableName) // get the order of the tables
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			newTemplate := utils.MakeTemplates(db, tableOrder)          // get a new blank template
+			updateTemplate(oldTemplate, newTemplate)                    // update the new template with the info in the old template
+			jsonBytes, err := json.MarshalIndent(newTemplate, "", "  ") // marshall the map
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			err = os.WriteFile(templatePath, jsonBytes, os.ModePerm)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+		} else {
+			log.Fatal("incorrect path to template. Please verify that the file exists")
+		}
+	},
+}
+
+func init() {
+	templateCmd.Flags().StringVarP(&templatePath, "path", "", "", "path to the template path")
+	templateCmd.Flags().StringVarP(&tableName, "table", "", "", "name of the table that the template was generated from")
+	err := templateCmd.MarkFlagRequired("path")
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = templateCmd.MarkFlagRequired("table")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// updateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// updateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func verifyTemplate(templatePath string) (map[string]map[string]map[string]string, error) {
+	m := make(map[string]map[string]map[string]string)
+	bytes, err := os.ReadFile(templatePath) // read the bytes
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(bytes, &m) // unmarshal the JSON
+	if err != nil {
+		return nil, err
+	}
+
+	// check the keys (doesn't verify the tables or columns yet)
+	for _, columns := range m {
+		for _, columnFields := range columns {
+			_, ok := columnFields["Code"]
+			if !ok {
+				return nil, errors.New("corrupted template file detected")
+			}
+			_, ok = columnFields["Type"]
+			if !ok {
+				return nil, errors.New("corrupted template file detected")
+			}
+			_, ok = columnFields["Value"]
+			if !ok {
+				return nil, errors.New("corrupted template file detected")
+			}
+		}
+	}
+	return m, nil
+}
+
+func updateTemplate(oldTemplate map[string]map[string]map[string]string, newTemplate map[string]map[string]map[string]string) {
+	for table, columns := range newTemplate {
+		for columnName := range columns {
+			_, ok := oldTemplate[table][columnName]
+			if ok {
+				newTemplate[table][columnName]["Code"] = oldTemplate[table][columnName]["Code"]   // set the code to the existing code
+				newTemplate[table][columnName]["Value"] = oldTemplate[table][columnName]["Value"] // set the value to the existing value
+			}
+		}
+	}
+}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -1,0 +1,53 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package update
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	ConnString string
+)
+
+// UpdateCmd represents the update command
+var UpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("update called")
+	},
+}
+
+func addSubCommands() {
+	UpdateCmd.AddCommand(templateCmd)
+}
+
+func init() {
+	UpdateCmd.PersistentFlags().StringVarP(&ConnString, "database", "", "", "url to connect to the database with")
+
+	if err := UpdateCmd.MarkPersistentFlagRequired("database"); err != nil {
+		log.Fatal(err)
+	}
+	addSubCommands()
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// updateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// updateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/validate/schema.go
+++ b/cmd/validate/schema.go
@@ -1,7 +1,6 @@
 package validate
 
 import (
-	"database/sql"
 	"fmt"
 	database "github.com/Keith1039/dbvg/db"
 	"github.com/Keith1039/dbvg/graph"
@@ -28,13 +27,8 @@ var schemaCmd = &cobra.Command{
 		dbvg validate schema --database ${POSTGRES_URL} --suggestions
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		db, err := InitDB()
-		defer func(db *sql.DB) {
-			err := db.Close()
-			if err != nil {
-				log.Fatal(err)
-			}
-		}(db)
+		db, err := database.InitDB(ConnString)
+		defer database.CloseDB(db)
 
 		if err != nil {
 			log.Fatal(err)

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -4,7 +4,6 @@
 package validate
 
 import (
-	"database/sql"
 	"github.com/spf13/cobra"
 	"log"
 )
@@ -13,7 +12,7 @@ var (
 	ConnString string
 )
 
-// validateCmd represents the validate command
+// ValidateCmd represents the validate command
 var ValidateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "The palette responsible for schema validation",
@@ -45,13 +44,4 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// validateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
-
-// InitDB initiates the database and returns it
-func InitDB() (*sql.DB, error) {
-	db, err := sql.Open("postgres", ConnString)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return db, nil
 }

--- a/db/db.go
+++ b/db/db.go
@@ -43,6 +43,20 @@ var typeMap = map[string]string{
 	"DATE":    "DATE",
 }
 
+// InitDB takes in a connection string and returns a database connection alongside any errors that occur
+func InitDB(connString string) (*sql.DB, error) {
+	db, err := sql.Open("postgres", connString)
+	return db, err
+}
+
+// CloseDB takes in a database connection and calls the Close() fun and logs any errors
+func CloseDB(db *sql.DB) {
+	err := db.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 // GetTableMap returns a map of existing table names mapped to the number 1 in the given database
 func GetTableMap(db *sql.DB) map[string]int {
 	tnames, err := schema.TableNames(db)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,14 @@
 package utils
 
-import "container/list"
+import (
+	"container/list"
+	"database/sql"
+	database "github.com/Keith1039/dbvg/db"
+	"github.com/jimsmart/schema"
+	"log"
+)
 
+// ListToStringArray takes in a linked list and returns it as a string array
 func ListToStringArray(l *list.List) []string {
 	// converts a linkedlist into a string array
 	arr := make([]string, l.Len())
@@ -13,4 +20,30 @@ func ListToStringArray(l *list.List) []string {
 		node = node.Next()                // move to the next node
 	}
 	return arr // return the array
+}
+
+// MakeTemplates takes in a database connection and an array of tables and formats it into a map suitable for JSON
+func MakeTemplates(db *sql.DB, tableOrder []string) map[string]map[string]map[string]string {
+	m := make(map[string]map[string]map[string]string)
+	relations := database.GetRelationships(db) // get relationships
+	for _, tName := range tableOrder {
+		m[tName] = makeTemplate(db, tName, relations)
+	}
+	return m
+}
+
+func makeTemplate(db *sql.DB, tName string, relations map[string]map[string]map[string]string) map[string]map[string]string {
+	m := make(map[string]map[string]string)
+	cols, err := schema.ColumnTypes(db, "", tName)
+	colMap := database.GetColumnMap(db, tName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, col := range cols {
+		_, ok := relations[tName][col.Name()] // check if the column is a fk
+		if !ok {
+			m[col.Name()] = map[string]string{"Type": colMap[col.Name()], "Code": "", "Value": ""}
+		}
+	}
+	return m
 }


### PR DESCRIPTION
This commit is focused on creating a new palette, `update`, with the `template` command. This palette is responsible for updating any data that is generated by the CLI. For now, it is only used for updating templates using the `template` command.

Due to this, a series of wider general changes were made in order to not repeat work.

The `db` package received 2 new functions, `InitDB()` and `CloseDB()`.
- `InitDB()`: Takes in a connection string and returns the database connection alongside any errors that occurred.
- `CloseDB()`: Takes in a database connection and closes it. It also logs any errors that occurred while closing.

These functions were made because each palette had their respective `InitDB()` function and a function to close a database connection. This was just repeated work. To fix that, these functions in the `db` package were created and will be imported by all palettes.

The `utils` package also received new functions. Because the logic for updating a template was similar to making one, the package received the `MakeTemplates()` and `makeTemplate()` functions.

- `MakeTemplates()`: Takes in a database connection and an array of tables and formats it into a map which is returned.
- `makeTemplate()`: Takes in a database connection and a table name. This is responsible for making the individual table's template map.

Finally, the last part of this commit is creating the `template` command for the `update` palette. This command verifies the integrity of the given template and overwrites it with an updated template. It also maps entries from the old template to the new template.