### PR TITLE
Task 14: New Command `queries` Created

### DIFF
--- a/cmd/generate/entry.go
+++ b/cmd/generate/entry.go
@@ -8,10 +8,10 @@ import (
 	"github.com/spf13/cobra"
 	"log"
 	"os"
+	"strings"
 )
 
 var (
-	table         string
 	template      string
 	amount        int
 	verbose       bool
@@ -43,6 +43,7 @@ examples:
 			log.Fatal(err)
 		}
 		tMap := database.GetTableMap(db)
+		table = strings.ToLower(table)
 		_, ok := tMap[table]
 		if !ok {
 			log.Fatalf("Table %s does not exist in database", table)
@@ -93,15 +94,11 @@ examples:
 
 func init() {
 	entryCmd.Flags().StringVarP(&template, "template", "", "", "path to the template file being used")
-	entryCmd.Flags().StringVarP(&table, "table", "", "", "table we are generating data for")
 	entryCmd.Flags().IntVarP(&amount, "amount", "", 1, "amount of entries this will generate")
 	entryCmd.Flags().BoolVarP(&defaultConfig, "default", "", false, "run using the default template")
 	entryCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Shows which queries are run and in what order")
-	entryCmd.Flags().BoolVarP(&cleanUp, "clean-up", "", false, "cleans up after generating data")
-	err := entryCmd.MarkFlagRequired("table")
-	if err != nil {
-		log.Fatal(err)
-	}
+	entryCmd.Flags().BoolVarP(&cleanUp, "clean-up", "c", false, "cleans up after generating data")
+
 	entryCmd.MarkFlagsOneRequired("template", "default")
 	entryCmd.MarkFlagsMutuallyExclusive("template", "default") // either use a template or use the default
 

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	ConnString string
+	table      string
 )
 
 // GenerateCmd represents the generate command
@@ -28,15 +29,21 @@ table entries using the entry command
 func addSubCommands() {
 	GenerateCmd.AddCommand(templateCmd)
 	GenerateCmd.AddCommand(entryCmd)
+	GenerateCmd.AddCommand(queriesCmd)
 }
 
 func init() {
 
 	GenerateCmd.PersistentFlags().StringVarP(&ConnString, "database", "", "", "url to connect to the database with")
+	GenerateCmd.PersistentFlags().StringVarP(&table, "table", "t", "", "name of sql table in the database")
 
 	if err := GenerateCmd.MarkPersistentFlagRequired("database"); err != nil {
 		log.Fatal(err)
 	}
+	if err := GenerateCmd.MarkPersistentFlagRequired("table"); err != nil {
+		log.Fatal(err)
+	}
+
 	addSubCommands()
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/generate/queries.go
+++ b/cmd/generate/queries.go
@@ -1,0 +1,121 @@
+/*
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
+*/
+package generate
+
+import (
+	"fmt"
+	database "github.com/Keith1039/dbvg/db"
+	"github.com/Keith1039/dbvg/parameters"
+	"github.com/spf13/cobra"
+	"log"
+	"os"
+	"strings"
+)
+
+var (
+	amounts      int
+	folder       string
+	defaultR     bool
+	templatePath string
+	name         string
+)
+
+// queriesCmd represents the queries command
+var queriesCmd = &cobra.Command{
+	Use:   "queries",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var writer *parameters.QueryWriter
+		var filePrefix string
+		var buildFile, cleanUpFile *os.File
+
+		db, err := database.InitDB(ConnString) // starts up database connection
+		defer database.CloseDB(db)             // closes the database connection
+		defer buildFile.Close()                // close the build up file
+		defer cleanUpFile.Close()              // close the cleanup file
+
+		if err != nil {
+			log.Fatal(err)
+		}
+		tMap := database.GetTableMap(db)
+		table = strings.ToLower(table) // make it lower case
+		_, ok := tMap[table]
+		if !ok {
+			log.Fatalf("Table %s does not exist in database", table)
+		}
+		if amount <= 0 {
+			log.Fatal("amount must be greater than zero")
+		}
+		if defaultR {
+			writer, err = parameters.NewQueryWriter(db, table)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			writer, err = parameters.NewQueryWriterWithTemplate(db, table, template)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+		insertQueries, deleteQueries := writer.GenerateEntries(amount)
+		name = strings.TrimSpace(name)
+		if name != "" {
+			filePrefix = table
+		} else {
+			filePrefix = name
+		}
+
+		folder := strings.TrimSpace(folder) // trim space
+		if folder[len(folder)-1:] != "/" {
+			folder = folder + "/"
+		}
+
+		buildFile, err = os.Create(fmt.Sprintf("%s%s_query.build.sql", folder, filePrefix))
+		if err != nil {
+			log.Fatal(err)
+		}
+		cleanUpFile, err = os.Create(fmt.Sprintf("%s%s_query.clean.sql", folder, filePrefix))
+		if err != nil {
+			log.Fatal(err)
+		}
+		writeToFile(buildFile, insertQueries)
+		writeToFile(cleanUpFile, deleteQueries)
+	},
+}
+
+func writeToFile(file *os.File, queries []string) {
+	for _, query := range queries {
+		_, err := fmt.Fprintln(file, query)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func init() {
+	queriesCmd.Flags().IntVarP(&amounts, "amount", "", 0, "Amount of queries to generate")
+	queriesCmd.Flags().StringVarP(&folder, "dir", "", "./", "Path to the directory for the file output")
+	queriesCmd.Flags().BoolVarP(&defaultR, "default", "", false, "Run with the default config")
+	queriesCmd.Flags().StringVarP(&templatePath, "template", "", "", "Path to the template file")
+	queriesCmd.Flags().StringVarP(&name, "name", "", "", "Name of the output files")
+
+	entryCmd.MarkFlagsOneRequired("template", "default")
+	entryCmd.MarkFlagsMutuallyExclusive("template", "default") // either use a template or use the default
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// queriesCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// queriesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/generate/template.go
+++ b/cmd/generate/template.go
@@ -13,8 +13,7 @@ import (
 )
 
 var (
-	dirPath   string
-	tableName string
+	dirPath string
 )
 
 // templateCmd represents the template command
@@ -37,7 +36,7 @@ example:
 		}
 		ordering := graph.NewOrdering(db)
 
-		tableOrder, err := ordering.GetOrder(strings.ToLower(tableName))
+		tableOrder, err := ordering.GetOrder(strings.ToLower(table))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -49,7 +48,7 @@ example:
 				log.Fatal(err)
 			}
 		}
-		err = os.WriteFile(fmt.Sprintf("%s/%s_template.json", dirPath, tableName), jsonString, os.ModePerm)
+		err = os.WriteFile(fmt.Sprintf("%s%s_template.json", dirPath, table), jsonString, os.ModePerm)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -58,15 +57,9 @@ example:
 }
 
 func init() {
-
-	templateCmd.Flags().StringVarP(&dirPath, "dir", "", "", "relative path of a directory to place the template file in, if the path doesn't exist it will make the folder")
-	templateCmd.Flags().StringVarP(&tableName, "table", "", "", "the name of the table we want an entry for")
+	templateCmd.Flags().StringVarP(&dirPath, "dir", "", "./", "relative path of a directory to place the template file in, if the path doesn't exist it will make the folder")
 
 	err := templateCmd.MarkFlagRequired("dir")
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = templateCmd.MarkFlagRequired("table")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This commit implements the `queries` command under the `generate` palette. The `queries` command generates and prints the insert queries to an output file instead of running them like `entry` does.

While some more work needs to be done on this, refactoring the CLI is the priority which is why this commit is going to be pretty bare bones.