### PR TITLE
Task 21.1: Clean Up

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,26 +124,36 @@ func main() {
 
 sample output:
 ```
-Query 1: ALTER TABLE e DROP COLUMN bref;
-Query 2: ALTER TABLE e DROP COLUMN bref2;
-Query 3: CREATE TABLE IF NOT EXISTS b_e(
-         b_bkey_ref INT4,
-         b_bkey2_ref INT4,
-         e_ekey_ref INT4,
-        FOREIGN KEY (b_bkey_ref, b_bkey2_ref) REFERENCES b(bkey, bkey2),
-        FOREIGN KEY (e_ekey_ref) REFERENCES e(ekey),
-        PRIMARY KEY (b_bkey_ref, b_bkey2_ref, e_ekey_ref)
+Query 1: CREATE TABLE IF NOT EXISTS b_a(
+         b_bkey INT4,
+         b_bkey2 INT4,
+         a_akey INT4,
+        FOREIGN KEY (b_bkey, b_bkey2) REFERENCES b(bkey, bkey2),
+        FOREIGN KEY (a_akey) REFERENCES a(akey),
+        PRIMARY KEY (b_bkey, b_bkey2, a_akey)
 )
+Query 2: INSERT INTO b_a(b_bkey, b_bkey2, a_akey)
+SELECT b.bkey, b.bkey2, a.akey
+FROM a
+INNER JOIN b
+ON a.bref = b.bkey AND a.bref2 = b.bkey2;
+Query 3: ALTER TABLE a DROP COLUMN bref2;
 Query 4: ALTER TABLE a DROP COLUMN bref;
-Query 5: ALTER TABLE a DROP COLUMN bref2;
-Query 6: CREATE TABLE IF NOT EXISTS b_a(
-         b_bkey_ref INT4,
-         b_bkey2_ref INT4,
-         a_akey_ref INT4,
-        FOREIGN KEY (b_bkey_ref, b_bkey2_ref) REFERENCES b(bkey, bkey2),
-        FOREIGN KEY (a_akey_ref) REFERENCES a(akey),
-        PRIMARY KEY (b_bkey_ref, b_bkey2_ref, a_akey_ref)
+Query 5: CREATE TABLE IF NOT EXISTS b_e(
+         b_bkey INT4,
+         b_bkey2 INT4,
+         e_ekey INT4,
+        FOREIGN KEY (b_bkey, b_bkey2) REFERENCES b(bkey, bkey2),
+        FOREIGN KEY (e_ekey) REFERENCES e(ekey),
+        PRIMARY KEY (b_bkey, b_bkey2, e_ekey)
 )
+Query 6: INSERT INTO b_e(b_bkey, b_bkey2, e_ekey)
+SELECT b.bkey, b.bkey2, e.ekey
+FROM e
+INNER JOIN b
+ON e.bref = b.bkey AND e.bref2 = b.bkey2;
+Query 7: ALTER TABLE e DROP COLUMN bref;
+Query 8: ALTER TABLE e DROP COLUMN bref2;
 ```
 
 ### Generate entries for a table [[schema used]](./db/real_migrations/000001_shop_example.up.sql)
@@ -161,7 +171,6 @@ import (
 )
 
 func main() {
-	os.Setenv("DATABASE_URL", "postgres://postgres:localDB12@localhost:5432/testgres?sslmode=disable")
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL")) // open the database connection
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,8 +1,14 @@
+*Note*: In all the examples, for the connection string I use an environmental variable, ${POSTGRES_URL}. That is
+because connections strings tend to be very long, and it would make the commands look less concise.
+You can represent the connection string any way you like so long as it is a valid sql connection string.
+
 # Common Uses
 
 ## Validate your database Schema using CLI
 
-`dbvg validate schema --database ${POSTGRES_URL}`
+``` shell
+dbvg validate schema --database "${POSTGRES_URL}"
+```
 
 Sample output:
 ```
@@ -11,7 +17,9 @@ Cycle Detected!: b --> d --> e --> b
 ```
 
 ## Resolve cycles using CLI [[schema used]](../db/migrations/case8/000001_create_compound_table.up.sql)
-`dbvg validate schema --database ${POSTGRES_URL} --run`
+``` shell
+dbvg validate schema --database "${POSTGRES_URL}" --run
+```
 
 Sample output:
 ```
@@ -41,15 +49,21 @@ Queries ran successfully
 ```
 
 ## Generate a template
-`dbvg template create --database ${POSTGRES_URL} --dir "templates/" --table "purchases" --name "purchase_template.json"`
+``` shell
+dbvg template create --database "${POSTGRES_URL}" --dir "templates/" --table "purchases" --name "purchase_template.json"
+```
 
 ## Update an existing template
-`dbvg template update --database ${POSTGRES_URL} --template ./templates/purchase_template.json  --table "purchases"`
+``` shell
+dbvg template update --database "${POSTGRES_URL}" --template ./templates/purchase_template.json  --table "purchases"
+```
 
 For more regarding templates, please see [this](generate/README.md)
 
 ## Generate a table entry [[schema used]](../db/real_migrations/000001_shop_example.up.sql)
-`dbvg generate entry --database ${POSTGRES_URL} --amount 1 --default --table "purchases" -v`
+``` shell
+dbvg generate entry --database "${POSTGRES_URL}" --amount 1 --default --table "purchases" -v
+```
 
 sample output:
 ```
@@ -62,17 +76,15 @@ Finished INSERT query execution!
 ```
 
 ### Generate INSERT and DELETE queries (with specified output file name)
-`dbvg generate queries --database ${POSTGRES_URL} --amount 1 --default --table "purchases" --name "purchase_queries"`
+``` shell
+dbvg generate queries --database "${POSTGRES_URL}" --amount 1 --default --table "purchases" --name "purchase_queries"
+```
 
 # CLI Usage Details
 
 The CLI has 3 subcommand palettes. These are `generate`, `template` and `validate`. `generate` focuses on
 generating table entries. `Template` focuses on generating and updating JSON template files. 
 Finally, `validate` focuses on cycle detection, suggestion and resolution.
-
-*Note*: In all the examples, for the connection string I use an environmental variable, ${POSTGRES_URL}. That is
-because connections strings tend to be very long, and it would make the commands look less concise.
-You can represent the connection string any way you like so long as it is a valid sql connection string.
 
 ## Subcommand Palette: generate
 This subcommand palette focuses on generating data. This data generation is either generating table entries
@@ -85,8 +97,8 @@ The user chooses if the table entries are generated from the default configurati
 or from a specified template file.
 
 examples:
-        dbvg generate entry --database ${POSTGRES_URL} --default --table "purchases" --verbose
-        dbvg generate entry --database ${POSTGRES_URL} --template "./templates/purchase_template.json" --table "purchases" --amount 10 -v --clean-up
+        dbvg generate entry --database "${POSTGRES_URL}" --default --table "purchases" --verbose
+        dbvg generate entry --database "${POSTGRES_URL}" --template "./templates/purchase_template.json" --table "purchases" --amount 10 -v --clean-up
 
 Usage:
   dbvg generate entry [flags]
@@ -142,8 +154,8 @@ Command used to generate a template JSON file in a specific folder for a group o
 The group of tables are the given table and all the tables it depends on.
 
 examples:
-        dbvg template create --database ${POSTGRES_URL} --dir "templates/"  --table "purchases"
-        dbvg template create --database ${POSTGRES_URL} --dir "./templates/"  --table "purchases" --name "purchase_template.json"
+        dbvg template create --database "${POSTGRES_URL}" --dir "templates/"  --table "purchases"
+        dbvg template create --database "${POSTGRES_URL}" --dir "./templates/"  --table "purchases" --name "purchase_template.json"
 
 Usage:
   dbvg template create [flags]
@@ -164,7 +176,7 @@ Command that updates an existing template. The command verifies for file corrupt
 the current template with the new one. This command also maps entries from the old template over to the new template, saving previous settings.
 
 example:
-        dbvg template update --database ${POSTGRES_URL} --template ./templates/purchase_template.json  --table "shop"
+        dbvg template update --database "${POSTGRES_URL}" --template ./templates/purchase_template.json  --table "shop"
 
 Usage:
   dbvg template update [flags]
@@ -189,8 +201,8 @@ These cycles can immediately be resolved by running a set of queries or
 these suggestions to the user.
 
 examples:
-        dbvg validate schema --database ${POSTGRES_URL} --run
-        dbvg validate schema --database ${POSTGRES_URL} --suggestions
+        dbvg validate schema --database "${POSTGRES_URL}" --run
+        dbvg validate schema --database "${POSTGRES_URL}" --suggestions
 
 Usage:
   dbvg validate schema [flags]

--- a/graph/helpers.go
+++ b/graph/helpers.go
@@ -1,0 +1,98 @@
+package graph
+
+import (
+	"container/list"
+	"github.com/Keith1039/dbvg/utils"
+	"strings"
+)
+
+func cleanCyclicPath(cString string) string {
+	allTables := strings.Split(cString, ",")
+	cycleTable := allTables[len(allTables)-1] // get the last table
+	flag := false
+	i := 0
+	for i < len(allTables) && !flag {
+		flag = allTables[i] == cycleTable // check to see if we found the table
+		if !flag {                        // if we didn't find it, increment i
+			i++
+		}
+	}
+	// the first string is also the last so we cut the last string off to not have duplicates in string
+	return strings.Join(allTables[i:], " --> ")
+}
+func getTablesMap(cycles []string) map[string]map[string]bool {
+	m := make(map[string]map[string]bool)
+
+	for _, cycle := range cycles {
+		l := make(map[string]bool)
+		cycleArr := strings.Split(cycle, " --> ") // get the array of strings
+		for i := 0; i < len(cycleArr)-1; i++ {    // we skip the last since it's a duplicate of the first
+			table := cycleArr[i]
+			l[table] = true // add the table to the map
+		}
+		m[cycle] = l // set the array
+	}
+	return m
+}
+
+func getFrequency(cycles []string) map[string]int {
+	m := make(map[string]int)
+	for _, cycle := range cycles {
+		if cycle != "" {
+			cycleArr := strings.Split(cycle, " --> ")
+			cycleArr = cycleArr[:len(cycleArr)-1]
+			for _, table := range cycleArr {
+				_, exists := m[table]
+				// unnecessary but it makes more sense this way
+				if !exists {
+					m[table] = 1
+				} else {
+					m[table] = m[table] + 1
+				}
+			}
+		}
+	}
+	return m
+}
+
+func getMostMentioned(fmap map[string]int) string {
+	var k string
+	var v int
+	// loop over the map
+	for key, value := range fmap {
+		if value > v { // check if the value of the current key is greater than current
+			k = key   // set the new key
+			v = value // set the new value
+		}
+	}
+	return k
+}
+
+func constructProblemTableMap(problemTable string, tableMap map[string]map[string]bool) map[string]bool {
+	relevantTablesMap := make(map[string]bool) // tables entry
+	for _, tables := range tableMap {          // go through each map for the cycles
+		if _, ok := tables[problemTable]; ok { // if problem table is in the cycle
+			for table := range tables { // loop through the keys (table)
+				if _, alreadyThere := relevantTablesMap[table]; !alreadyThere { // check if the table already has an entry
+					relevantTablesMap[table] = true // add the entry
+				}
+			}
+		}
+	}
+	return relevantTablesMap // return the problem table map
+}
+
+func getRelevantKeys(relations map[string]map[string]map[string]string, tableName string, refTableName string) []string {
+	tableRelations := relations[refTableName] // get the map of FKs
+	relevantKeys := list.New()                // make a new list
+
+	for col, colRelations := range tableRelations { //loop through the map
+		if colRelations["Table"] == tableName && tableName != refTableName { // see if this key is for referencing the same table and ISN'T the same table
+			relevantKeys.PushBack(colRelations["Column"]) // add the referenced column to the list
+		} else if colRelations["Table"] == tableName { // condition where it is the same table
+			relevantKeys.PushBack(col) // add the column to the list
+		}
+	}
+	// by definition this array should be at minimum, size: 1
+	return utils.ListToStringArray(relevantKeys) // return an array version of the list
+}

--- a/graph/writers.go
+++ b/graph/writers.go
@@ -1,0 +1,160 @@
+package graph
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+func getColumnQuery(pk string, newPK string, colMap map[string]*sql.ColumnType) string {
+	var queryString string
+	precision, scale, ok := colMap[pk].DecimalSize() // check to see if it's a variable float type
+	databaseType := colMap[pk].DatabaseTypeName()
+	// pretty unnecessary but oh well
+	if databaseType == "FLOAT4" || databaseType == "FLOAT8" {
+		switch databaseType {
+		case "FLOAT4":
+			queryString = fmt.Sprintf("\n\t %s %s,", newPK, "REAL")
+		case "FLOAT8":
+			queryString = fmt.Sprintf("\n\t %s %s,", newPK, "DOUBLE PRECISION")
+		}
+	} else {
+		if ok {
+			// NUMERIC types default is (65535, 65531) so we avoid that
+			if precision != 65535 && scale != 65531 {
+				queryString = fmt.Sprintf("\n\t %s %s(%d, %d),", newPK, databaseType, precision, scale) // add the precision to the new query
+			} else {
+				queryString = fmt.Sprintf("\n\t %s %s,", newPK, databaseType) // solely for NUMERIC
+			}
+		} else {
+			length, isVarchar := colMap[pk].Length() // get the size of the column
+			if isVarchar && databaseType != "TEXT" { // text is excluded from this
+				if databaseType == "VARCHAR" && length != -5 { // exclude default varchar
+					queryString = fmt.Sprintf("\n\t %s %s(%d),", newPK, databaseType, length)
+				} else if databaseType == "BPCHAR" {
+					if length != -5 && length != 1 { // exclude default BPCHAR and CHAR
+						queryString = fmt.Sprintf("\n\t %s %s(%d),", newPK, databaseType, length)
+					} else if length == 1 {
+						queryString = fmt.Sprintf("\n\t %s %s,", newPK, "CHAR")
+					} else {
+						queryString = fmt.Sprintf("\n\t %s %s,", newPK, databaseType)
+					}
+				}
+			} else {
+				queryString = fmt.Sprintf("\n\t %s %s,", newPK, databaseType) // in case all other conditions fail
+			}
+		}
+	}
+	return queryString
+}
+
+func appendBuilder(builder *strings.Builder, pks []string, table string, colMap map[string]*sql.ColumnType, newTablePKs []string, slider *int) {
+	// appends the new column name and the datatype
+	for _, pk := range pks {
+		newPK := fmt.Sprintf("%s_%s", table, pk)
+		queryString := getColumnQuery(pk, newPK, colMap)
+		builder.WriteString(queryString)
+		newTablePKs[*slider] = newPK // assign the new pk to the array
+		*slider++                    // increment slider
+	}
+}
+
+func appendDropBuilder(builder *strings.Builder, refTable string, problemTable string, allRelations map[string]map[string]map[string]string) {
+	relations := allRelations[problemTable]
+	for column, relation := range relations {
+		if relation["Table"] == refTable { // check to see if the fk matches
+			builder.WriteString(fmt.Sprintf("ALTER TABLE %s DROP COLUMN %s;\n", problemTable, column))
+		}
+	}
+}
+
+func appendColumnBuilder(builder *strings.Builder, relations map[string]map[string]map[string]string, newTablePks []string, refTable string, problemTable string, problemTableKeys []string, refTablePKs []string) {
+	// builds the join query that moves existing data over to the new translation table
+	var conditionBuilder strings.Builder  // builder for our join condition
+	var selectBuilder strings.Builder     // builder for our select statement
+	tableRelations := relations[refTable] // map of table relationships
+	newTableName := fmt.Sprintf("%s_%s", problemTable, refTable)
+	builder.WriteString(fmt.Sprintf("INSERT INTO %s(%s)\n", newTableName, strings.Join(newTablePks, ", ")))
+	if problemTable != refTable {
+		for _, key := range problemTableKeys {
+			if selectBuilder.String() == "" {
+				selectBuilder.WriteString(fmt.Sprintf("%s.%s", problemTable, key))
+			} else {
+				selectBuilder.WriteString(fmt.Sprintf(", %s.%s", problemTable, key))
+			}
+		}
+
+		for _, key := range refTablePKs {
+			selectBuilder.WriteString(fmt.Sprintf(", %s.%s", refTable, key))
+		}
+		for column, relation := range tableRelations {
+			if relation["Table"] == problemTable {
+				if conditionBuilder.String() == "" { // check to see if it's the first condition
+					conditionBuilder.WriteString(fmt.Sprintf("%s.%s = %s.%s", refTable, column, problemTable, relation["Column"]))
+				} else {
+					conditionBuilder.WriteString(fmt.Sprintf(" AND %s.%s = %s.%s", refTable, column, problemTable, relation["Column"]))
+				}
+			}
+		}
+		// form the SELECT query for INNER-JOIN
+		builder.WriteString(fmt.Sprintf("SELECT %s\n", selectBuilder.String()))
+		builder.WriteString(fmt.Sprintf("FROM %s\n", refTable))
+		builder.WriteString(fmt.Sprintf("INNER JOIN %s\n", problemTable))
+		builder.WriteString(fmt.Sprintf("ON %s;", conditionBuilder.String()))
+	} else {
+		// since it's the same table we can just take from T1 table
+		for _, key := range append(problemTableKeys, refTablePKs...) {
+			if selectBuilder.String() == "" {
+				selectBuilder.WriteString(fmt.Sprintf("T1.%s", key))
+			} else {
+				selectBuilder.WriteString(fmt.Sprintf(", T1.%s", key))
+			}
+		}
+		for column, relation := range tableRelations {
+			if relation["Table"] == problemTable {
+				if conditionBuilder.String() == "" { // check to see if it's the first condition
+					conditionBuilder.WriteString(fmt.Sprintf("T1.%s = T2.%s", column, relation["Column"]))
+				} else {
+					conditionBuilder.WriteString(fmt.Sprintf(" AND T1.%s = T2.%s", column, relation["Column"]))
+				}
+			}
+		}
+		// form the SELECT query for SELF-JOIN
+		builder.WriteString(fmt.Sprintf("SELECT %s\n", selectBuilder.String()))
+		builder.WriteString(fmt.Sprintf("FROM %s AS T1, %s AS T2\n", refTable, problemTable))
+		builder.WriteString(fmt.Sprintf("WHERE %s;", conditionBuilder.String()))
+	}
+
+}
+
+func appendForeignKey(foreignKeyBuilder *strings.Builder, relationships map[string]map[string]map[string]string, problemTable string, problemTableKeys []string, refTable string, refTablePks []string, newTablePks []string) {
+	// builds a foreign key constraint
+	var refBuilder strings.Builder
+	allKeys := strings.Join(newTablePks[0:len(problemTableKeys)], ", ") // all the problem keys as a string
+	if problemTable == refTable {                                       // check if it's a self reference
+		for _, key := range problemTableKeys { // loop through keys to create the reference
+			col := relationships[problemTable][key]["Column"] // the column that the key is referencing
+			// format the referenced keys
+			if refBuilder.String() == "" {
+				refBuilder.WriteString(col)
+			} else {
+				refBuilder.WriteString(fmt.Sprintf(", %s", col))
+			}
+		}
+	} else {
+		// if it isn't a self reference then just join the keys
+		refBuilder.WriteString(strings.Join(problemTableKeys, ", ")) // append to ref builder
+	}
+	// format foreign key for the problem table
+	foreignKeyBuilder.WriteString(fmt.Sprintf("\n\tFOREIGN KEY (%s) REFERENCES %s(%s),", allKeys, problemTable, refBuilder.String()))
+	allKeys = strings.Join(newTablePks[len(problemTableKeys):], ", ") // format the referenced tables primary keys as a string
+	refPks := strings.Join(refTablePks, ", ")                         // string version of the referenced primary keys
+	// format foreign key for ref table
+	foreignKeyBuilder.WriteString(fmt.Sprintf("\n\tFOREIGN KEY (%s) REFERENCES %s(%s),", allKeys, refTable, refPks))
+}
+
+func appendPrimaryKeys(primaryKeyBuilder *strings.Builder, pks []string) {
+	// builds the primary key constraint
+	allKeys := strings.Join(pks, ", ")                          // convert array to string and add it to builder
+	primaryKeyBuilder.WriteString(fmt.Sprintf("(%s)", allKeys)) // format string and add it to builder
+}


### PR DESCRIPTION
This commit is all about updating the codebase to make it clearer.

To do this, the README file examples were updated to include the `INSERT` queries which were added from the last commit. There was also some format changes and some markdown updates, namely identifying any shell commands as shell commands.

Another change was partitioning the existing code from `ordering.go`. `ordering.go` had too many functions and this made it difficult to make changes. As such, two new files were created for this sake, `writers.go` and `helpers.go`.

`writers.go` contains the functions that are responsible for creating the `SQL` queries that the program uses.

`helpers.go` contains other functions that are used by the `Ordering` struct.

Finally, I got rid of the postgres URL that was accidently added to the examples.

Other Changes:
- {POSTGRES_URL} --> "{POSTGRES_URL}" in the examples