### PR TITLE
Task 23: Add CLI option to output SQL script

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -4,12 +4,22 @@
 package validate
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
+	database "github.com/Keith1039/dbvg/db"
+	"github.com/Keith1039/dbvg/graph"
+	"github.com/Keith1039/dbvg/utils"
 	"github.com/spf13/cobra"
 	"log"
 )
 
 var (
-	ConnString string
+	ConnString  string
+	run         bool
+	suggestions bool
+	verbose     bool
+	output      string
 )
 
 // ValidateCmd represents the validate command
@@ -45,4 +55,56 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// validateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func handleCmdFlags(db *sql.DB, ordering *graph.Ordering, cycles []string) {
+	var err error
+	if suggestions || run { // global variables
+		// functional equivalent to calling `GetSuggestionQueries` in some cases
+		suggestionQueries := ordering.GetSuggestionQueriesForCycles(cycles)
+		if len(suggestionQueries) == 0 { // print that there's nothing to do
+			fmt.Println("No suggestions to be made")
+		}
+		if suggestions {
+			if output != "" { // write queries to file if there is one specified
+				err = utils.WriteQueriesToFile(output, suggestionQueries)
+				if err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				for i, query := range suggestionQueries { // print out each query
+					fmt.Println(fmt.Sprintf("Query %d: %s", i+1, query))
+				}
+			}
+		} else if run {
+			if verbose { // only print each query if verbose is specified
+				err = database.RunQueriesVerbose(db, suggestionQueries)
+				if err != nil {
+					log.Fatal(err)
+				}
+			} else { // run silently
+				err = database.RunQueries(db, suggestionQueries)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+			fmt.Println("Queries ran successfully")
+		}
+	}
+}
+
+func addFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(&run, "run", "r", false, "run suggestions queries")
+	cmd.Flags().BoolVarP(&suggestions, "suggestions", "s", false, "show suggestion queries")
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "output file name")
+	cmd.MarkFlagsMutuallyExclusive("suggestions", "run")          // either you want the suggestions or you run them
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error { // define the pre-run function
+		flagSet := cmd.Flags()                                            // get flag set
+		if flagSet.Changed("output") && !flagSet.Changed("suggestions") { // check to see if output is set but suggestions isn't
+			return errors.New("'suggestions' flag must be set for 'output' flag to be used") // format error
+		}
+		return nil
+	}
+	cmd.MarkFlagsMutuallyExclusive("run", "output") // if you're running the queries there's no need to output them
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,9 +3,13 @@ package utils
 import (
 	"container/list"
 	"database/sql"
+	"errors"
+	"fmt"
 	database "github.com/Keith1039/dbvg/db"
 	"github.com/jimsmart/schema"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -52,4 +56,57 @@ func makeTemplate(db *sql.DB, tName string, relations map[string]map[string]map[
 // TrimAndLowerString trims space and lowers the given string
 func TrimAndLowerString(s string) string {
 	return strings.ToLower(strings.TrimSpace(s))
+}
+
+func WriteQueriesToFile(path string, queries []string) error {
+	// by default this will overwrite existing files
+	testPath := strings.TrimSpace(path)
+	if testPath == "" {
+		return errors.New("path is empty")
+	} else if filepath.Dir(testPath) == filepath.Clean(testPath) { // the two strings shouldn't be equal if there's a filepath specified
+		return errors.New("no file name specified")
+	}
+	path = filepath.Clean(testPath)       // clean the path
+	dir, fileName := filepath.Split(path) // split the dir path and the file name
+	if fileName == "" {                   // check to see if there is a valid file name
+		return errors.New("file name not specified") // error out
+	}
+	if dir != "" { // check if the dir path is empty string
+		if _, err := os.Stat(dir); os.IsNotExist(err) { // check if directory exists
+			err = os.MkdirAll(dir, os.ModePerm) // make all directories and subdirectories
+			if err != nil {
+				return err // log error and exit
+			}
+		}
+	}
+	file, err := os.Create(filepath.Join(dir, fileName)) // create the file name
+	if err != nil {                                      // error check
+		return err
+	}
+	defer file.Close()                // close the file
+	return writeToFile(file, queries) // write the queries to the file
+}
+
+func writeToFile(file *os.File, queries []string) error {
+	// edge cases to avoid appending any sort of junk data to file
+	if len(queries) == 0 || (len(queries) == 1 && queries[0] == "") {
+		return nil
+	}
+	// writes all the queries to the file
+	for i, query := range queries {
+		var err error
+		if i == len(queries)-1 { // last index
+			_, err = file.WriteString(query) // write to file with line separator
+		} else {
+			_, err = file.WriteString(fmt.Sprintf("%s\n", query)) // write to file
+		}
+		if err != nil { // error check
+			return err
+		}
+	}
+	err := file.Sync() // synch file
+	if err != nil {    // error check
+		return err
+	}
+	return nil
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func checkFileContents(t *testing.T, path string, expected []string) {
+	path = filepath.Clean(strings.TrimSpace(path)) // WriteQueriesToFile does the same preprocessing, so I'll add some here
+	bytes, err := os.ReadFile(path)                // read files
+	if err != nil {                                // error check
+		t.Fatal(err)
+	}
+	stringArr := strings.Split(string(bytes), "\n") // get the array
+	if !slices.Equal(stringArr, expected) {         // check if the two arrays match
+		t.Fatal(fmt.Sprintf("File content %s does not match the expected content of %s", stringArr, expected))
+	}
+}
+
+func TestWriteQueriesToFile(t *testing.T) {
+	dir := t.TempDir()
+	path1 := fmt.Sprintf("%s/test1.txt", dir)                       // see if a test file with no message can be handled
+	path2 := fmt.Sprintf("   %s/something/some/test2.txt    ", dir) // make multiple sub-subdirectories with whitespace in path
+	path3 := fmt.Sprintf("%s/something/test3", dir)                 // see if an extension is enforced
+	path4 := fmt.Sprintf("%s/something/test4/", dir)                // this should fail because no file name is specified
+	path5 := ""                                                     // see if empty string is handled properly
+
+	message1 := []string{""}
+	message2 := []string{"message2", "message2.1"}
+	message3 := []string{"message3", "message3.1", "message3.2", "message3.3"}
+	// evaluate first test case
+	err := WriteQueriesToFile(path1, message1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkFileContents(t, path1, message1) // evaluate the file's contents
+
+	// evaluate second test case
+	err = WriteQueriesToFile(path2, message2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkFileContents(t, path2, message2) // evaluate the file's contents
+
+	// evaluate third test case
+	err = WriteQueriesToFile(path3, message3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkFileContents(t, path3, message3) // evaluate the file's contents
+
+	err = WriteQueriesToFile(path4, []string{})
+	if err == nil { // no file should have caused an error
+		t.Fatalf("path %s should have caused an error", path4)
+	}
+
+	err = WriteQueriesToFile(path5, []string{})
+	if err == nil { // empty string should have returned an error
+		t.Fatalf("empty string should have caused an error to be returned")
+	}
+}


### PR DESCRIPTION
This commit allows the SQL code responsible for fixing cycles to be output to a file. This is done by adding a new flag `---output, -o`

This change affects the two commands `schema` and `table` in the `validate` suit of commands. In order to accommodate this new change, new functions were created to simplify certain processes.

A new command in `utils` called `WriteQueriesToFile()` is responsible for writing the array of queries to a given path. This function also handles all of the path validation, returning any errors it encounters. This function effectively deals with anything that has a `--output, -o` flag enabled.

To ensure that `WriteQueriesToFile()` behaves as intended, unit tests for it were created in the new file `utils_test.go`.

Another command was added to the `Ordering` struct called `GetSuggestionQueriesForCycles()`. This function is identical to the `GetSuggestionQueries()` function except it only gives suggestions based on the cycles it was given rather then all of the cycles in the schema. In some cases, calling this function is identical to calling `GetSuggestionQueries()`

To help with cohesion, most of the global private variables in each command were moved over to the `validate.go` file. This was because the two commands (`schema` and `table`) needed the same set of flags and using synonyms was a waste of time. New private functions were created for the `schema` and `table` commands. These functions are `addFlags()` and `handleCmdFlags()`. This was because there were similar processes in the two functions that could be turned into a general function.

`addFlags()` adds the following flags to the given command `run`, `suggestions`, `verbose` and `output`. It also makes `suggestion` and `run` mutually exclusive and `suggestion` and `output` mutually inclusive through the `PreRunE` function. This is so that the commands have the same behavior when it comes to their shared flags.

`handleCmdFlags()` outlines the behavior for the commands `schema` and `table` since they have identical logic for a certain portion of their code. This ensures that the two commands have the same behavior when it comes to processing their flags.

Other Changes:
- Added function `ResolveGivenCycles()` to be used in tandem with the `GetCyclesForTable()` function. This is to give users the option to resolve a subset of cycles without using the CLI
- `writeToFile()` private function created to actually write input to a file
- updating command descriptions