### PR TITLE
Task 24.2: Optimizing Query Generation

### DIFF
--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -77,16 +77,9 @@ func handleCmdFlags(db *sql.DB, ordering *graph.Ordering, cycles []string) {
 				}
 			}
 		} else if run {
-			if verbose { // only print each query if verbose is specified
-				err = database.RunUnsafeQueriesVerbose(db, suggestionQueries)
-				if err != nil {
-					log.Fatal(err)
-				}
-			} else { // run silently
-				err = database.RunUnsafeQueries(db, suggestionQueries)
-				if err != nil {
-					log.Fatal(err)
-				}
+			err = database.RunUnsafeQueries(db, suggestionQueries, verbose)
+			if err != nil {
+				log.Fatal(err)
 			}
 			fmt.Println("Queries ran successfully")
 		}

--- a/db/db.go
+++ b/db/db.go
@@ -209,14 +209,18 @@ func GetInverseRelationships(db *sql.DB) map[string]map[string]bool {
 
 // RunUnsafeQueries runs a given list of queries and returns any errors the moment they happen.
 // the queries are run in a db transaction so a ny error will trigger a rollback
-// this method is unsafe as it simply pipes the queries into db.Exec making it vulnerable to SQL injection
-func RunUnsafeQueries(db *sql.DB, queries []string) error {
+// this method is unsafe as it simply pipes the queries into db.Exec making it vulnerable to SQL injection.
+// If the verbose flag is true, the query will be printed before being executed to help with debugging
+func RunUnsafeQueries(db *sql.DB, queries []string, verbose bool) error {
 	tx, err := db.BeginTx(context.Background(), nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback() // we don't really care if rollback has an error
-	for _, query := range queries {
+	for i, query := range queries {
+		if verbose {
+			fmt.Println(fmt.Sprintf("Query %d: %s", i+1, query))
+		}
 		_, err = tx.Exec(query)
 		if err != nil {
 			return err
@@ -227,27 +231,4 @@ func RunUnsafeQueries(db *sql.DB, queries []string) error {
 		return err
 	}
 	return nil
-}
-
-// RunUnsafeQueriesVerbose runs a given list of queries but prints them out before executing them
-// the queries are run in a db transaction so a ny error will trigger a rollback
-// this method is unsafe as it simply pipes the queries into db.Exec making it vulnerable to SQL injection
-func RunUnsafeQueriesVerbose(db *sql.DB, queries []string) error {
-	tx, err := db.BeginTx(context.Background(), nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback() // we don't really care if rollback has an error
-	for i, query := range queries {
-		fmt.Println(fmt.Sprintf("Query %d: %s", i+1, query))
-		_, err = tx.Exec(query)
-		if err != nil {
-			return err
-		}
-	}
-	err = tx.Commit() // commit if there are no errors
-	if err != nil {
-		return err
-	}
-	return err
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -397,7 +397,7 @@ func TestRunUnsafeQueries(t *testing.T) {
 		fmt.Sprintf("INSERT INTO USERS(ID, FIRST_NAME, LAST_NAME, EMAIL, ADDRESS, CREATED_AT) VALUES ('%v', '%v', '%v', '%v', '%v', '%v')", uuid.New(), "some", "name", "test@gmail.com", "SOMETHING", time.Now().Format("2006-01-02 15:04:05")),
 		fmt.Sprintf("INSERT INTO USERS(ID, FIRST_NAME, LAST_NAME, EMAIL, ADDRESS, CREATED_AT) VALUES ('%v', '%v', '%v', '%v', '%v', '%v')", uuid.New(), "some", "name", "test2@gmail.com", "SOMETHING", time.Now().Format("2006-01-02 15:04:05")),
 	}
-	err = database.RunUnsafeQueries(db, queries)
+	err = database.RunUnsafeQueries(db, queries, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func TestRunUnsafeQueries(t *testing.T) {
 	queries = []string{
 		fmt.Sprintf("INSERT INTO USERS(ID, FIRST_NAME, LAST_NAME, EMAIL, ADDRESS, CREATED_AT) VALUES ('%v', '%v', '%v', '%v', '%v', '%v')", uuid.New(), "some", "name", "test@gmail.com", "SOMETHING", time.Now().Format("2006-01-02 15:04:05")),
 	}
-	err = database.RunUnsafeQueries(db, queries)
+	err = database.RunUnsafeQueries(db, queries, false)
 	if err == nil {
 		t.Fatal("query should violate emails unique constraint")
 	}

--- a/graph/ordering.go
+++ b/graph/ordering.go
@@ -97,8 +97,8 @@ func (tl *Ordering) GetSuggestionQueriesForCycles(cycles []string) []string {
 func (tl *Ordering) GetAndResolveCycles() {
 	cycles := tl.GetCycles() // get your cycles
 	cycleBreaking, relMap := tl.getCycleBreakingOrder(cycles)
-	suggestions := tl.getSuggestions(cycleBreaking, relMap) // get your suggestions
-	err := database.RunUnsafeQueries(tl.db, suggestions)    // run the suggestions
+	suggestions := tl.getSuggestions(cycleBreaking, relMap)     // get your suggestions
+	err := database.RunUnsafeQueries(tl.db, suggestions, false) // run the suggestions
 	if err != nil {
 		log.Fatal(err) // panic if it fails
 	}
@@ -107,8 +107,8 @@ func (tl *Ordering) GetAndResolveCycles() {
 // ResolveGivenCycles gets suggestion queries for the given cycles and runs them similar to GetAndResolveCycles
 func (tl *Ordering) ResolveGivenCycles(cycles []string) {
 	cycleBreaking, relMap := tl.getCycleBreakingOrder(cycles)
-	suggestions := tl.getSuggestions(cycleBreaking, relMap) // get your suggestions
-	err := database.RunUnsafeQueries(tl.db, suggestions)    // run the suggestions
+	suggestions := tl.getSuggestions(cycleBreaking, relMap)     // get your suggestions
+	err := database.RunUnsafeQueries(tl.db, suggestions, false) // run the suggestions
 	if err != nil {
 		log.Fatal(err) // panic if it fails
 	}

--- a/parameters/batch.go
+++ b/parameters/batch.go
@@ -1,7 +1,6 @@
 package parameters
 
 import (
-	"container/list"
 	"context"
 	"database/sql"
 	"fmt"
@@ -10,13 +9,28 @@ import (
 )
 
 type queryBatch struct {
-	queryList  *list.List
-	paramsList *list.List
+	size       int
+	slider     int
+	queryList  []string
+	paramsList [][]any
 }
 
-func (q *queryBatch) init() {
-	q.queryList = list.New()
-	q.paramsList = list.New()
+func (q *queryBatch) init(size int) {
+	q.queryList = make([]string, size)
+	q.paramsList = make([][]any, size)
+	q.size = size
+}
+
+func (q *queryBatch) append(query string, params []any) {
+	q.queryList[q.slider] = query
+	q.paramsList[q.slider] = params
+	q.slider++
+}
+
+func (q *queryBatch) reverseAppend(query string, params []any) {
+	q.queryList[q.size-q.slider-1] = query
+	q.paramsList[q.size-q.slider-1] = params
+	q.slider++
 }
 
 func (q *queryBatch) executeBatch(ctx context.Context, db *sql.DB, verbose bool) error {
@@ -37,22 +51,15 @@ func (q *queryBatch) executeBatch(ctx context.Context, db *sql.DB, verbose bool)
 }
 
 func (q *queryBatch) executeBatchAsTransaction(ctx context.Context, tx *sql.Tx, verbose bool) error {
-	i := 1
-	node := q.queryList.Front()
-	paramNode := q.paramsList.Front()
-	for node != nil {
-		query := node.Value.(string)
-		params := paramNode.Value.([]any)
+	for i, query := range q.queryList {
+		params := q.paramsList[i]
 		if verbose {
-			fmt.Println(fmt.Sprintf("executing query %d: '%s' with parameters: %v", i, query, arrayAsString(params)))
+			fmt.Println(fmt.Sprintf("executing query %d: '%s' with parameters: %v", i+1, query, arrayAsString(params)))
 		}
 		_, err := tx.ExecContext(ctx, query, params...)
 		if err != nil {
 			return err
 		}
-		i++
-		node = node.Next()
-		paramNode = paramNode.Next()
 	}
 	return nil
 }
@@ -74,7 +81,7 @@ func (q *queryBatch) ExecTransactContext(ctx context.Context, tx *sql.Tx, verbos
 }
 
 func (q *queryBatch) Size() int {
-	return q.queryList.Len()
+	return len(q.queryList)
 }
 
 type InsertBatch struct {

--- a/parameters/helpers.go
+++ b/parameters/helpers.go
@@ -1,31 +1,18 @@
 package parameters
 
 import (
-	"container/list"
 	"fmt"
-	"github.com/Keith1039/dbvg/utils"
 )
 
-func getAllColumnNames(columns []*column) []string {
-	l := list.New()
-	for _, col := range columns {
-		l.PushBack(col.ColumnName)
+func getQueryParams(columns []*column) ([]string, []string, []string) {
+	colLen := len(columns)
+	allColumns := make([]string, colLen)
+	paramStrings := make([]string, colLen)
+	deleteQuery := make([]string, colLen)
+	for i, col := range columns {
+		allColumns[i] = col.ColumnName
+		paramStrings[i] = fmt.Sprintf("$%d", i+1)
+		deleteQuery[i] = fmt.Sprintf("%s=%s", allColumns[i], paramStrings[i])
 	}
-	return utils.ListToStringArray(l)
-}
-
-func createParameterString(length int) []string {
-	arr := make([]string, length)
-	for i := 0; i < length; i++ {
-		arr[i] = fmt.Sprintf("$%d", i+1)
-	}
-	return arr
-}
-
-func createDeleteQuery(allColumn, parameterString []string) []string {
-	l := list.New()
-	for i, col := range allColumn {
-		l.PushBack(fmt.Sprintf("%s=%s", col, parameterString[i]))
-	}
-	return utils.ListToStringArray(l)
+	return allColumns, paramStrings, deleteQuery
 }

--- a/parameters/query_writer.go
+++ b/parameters/query_writer.go
@@ -4,7 +4,6 @@
 package parameters
 
 import (
-	"container/list"
 	"database/sql"
 	"fmt"
 	database "github.com/Keith1039/dbvg/db"
@@ -98,8 +97,9 @@ func (qw *QueryWriter) setFKMap() {
 func (qw *QueryWriter) GenerateEntries(amount int) (*InsertBatch, *DeleteBatch) {
 	insertBatch := &InsertBatch{}
 	deleteBatch := &DeleteBatch{}
-	insertBatch.init()
-	deleteBatch.init()
+	total := len(qw.tableMap) * amount // expected total
+	insertBatch.init(total)
+	deleteBatch.init(total)
 
 	for i := 0; i < amount; i++ {
 		for _, tableName := range qw.TableOrder {
@@ -116,37 +116,34 @@ func (qw *QueryWriter) GenerateEntry() (*InsertBatch, *DeleteBatch) {
 }
 
 func (qw *QueryWriter) processTable(tableName string, insertBatch *InsertBatch, deleteBatch *DeleteBatch) {
-	//var writer SQLWriter
+	var colVal any
+	var err error
 	t := qw.tableMap[tableName]
-	allColumns := getAllColumnNames(t.Columns)
-	paraString := createParameterString(len(t.Columns))
-	deleteQuery := createDeleteQuery(allColumns, paraString)
-	l := list.New()
+	allColumns, paraString, deleteQuery := getQueryParams(t.Columns)
+	i := 0
+	parameterArr := make([]any, len(allColumns))
 	for _, col := range t.Columns {
 		fkRelation, fk := qw.allRelations[tableName][col.ColumnName]
 		if fk {
-			colVal := qw.fkMap[fkRelation["Table"]][fkRelation["Column"]] // retrieve the stored foreign key value
-			l.PushBack(colVal)
+			colVal = qw.fkMap[fkRelation["Table"]][fkRelation["Column"]] // retrieve the stored foreign key value
 		} else {
-			colVal, err := col.Pair.Strategy.ExecuteStrategy()
+			colVal, err = col.Pair.Strategy.ExecuteStrategy()
 			if err != nil {
 				log.Fatalf("strategy execution for code '%s' failed for column '%s' of table '%s'", col.Pair.Code, col.ColumnName, tableName)
 			}
-			l.PushBack(colVal)
 			_, isFK := qw.fkMap[tableName][col.ColumnName]
 			if isFK {
 				qw.fkMap[tableName][col.ColumnName] = colVal
 			}
 		}
+		parameterArr[i] = colVal
+		i++
 	}
-	parameterArr := utils.ListToAnyArray(l)
 	query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s);", t.TableName, strings.Join(allColumns, ", "), strings.Join(paraString, ", "))
-	insertBatch.queryList.PushBack(query)
-	insertBatch.paramsList.PushBack(parameterArr)
+	insertBatch.append(query, parameterArr)
 
 	query = fmt.Sprintf("DELETE FROM %s WHERE %s;", tableName, strings.Join(deleteQuery, " AND "))
-	deleteBatch.queryList.PushFront(query)
-	deleteBatch.paramsList.PushFront(parameterArr)
+	deleteBatch.reverseAppend(query, parameterArr)
 }
 
 func (qw *QueryWriter) setTableMap() {

--- a/parameters/query_writer_test.go
+++ b/parameters/query_writer_test.go
@@ -9,11 +9,30 @@ import (
 	"testing"
 )
 
+const realMigrationPath = "file://../db/real_migrations/"
+
 func buildUpCase(caseName string) error {
 	// migrate the schema up
 	driver, err := postgres.WithInstance(db, &postgres.Config{})
 	m, err2 := migrate.NewWithDatabaseInstance(
 		"file://../db/migrations/"+caseName,
+		"postgres", driver)
+	if m != nil {
+		err = m.Up()
+		if err != nil {
+			return err
+		}
+	} else {
+		return err2
+	}
+	return nil
+}
+
+func buildUpRealCase() error {
+	// migrate the schema up
+	driver, err := postgres.WithInstance(db, &postgres.Config{})
+	m, err2 := migrate.NewWithDatabaseInstance(
+		realMigrationPath,
 		"postgres", driver)
 	if m != nil {
 		err = m.Up()
@@ -61,4 +80,22 @@ func TestQueryWriter_GenerateEntries(t *testing.T) {
 	if deleteBatch.Size() != expectedAmount {
 		t.Fatalf("deleteBatch.Size() returned %d instead of %d", deleteBatch.Size(), expectedAmount)
 	}
+}
+
+func BenchmarkGenerateQueries(b *testing.B) {
+	drop()
+	err := buildUpRealCase()
+	if err != nil {
+		b.Fatal(err)
+	}
+	writer, err := parameters.NewQueryWriter(db, "purchases")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for range b.N {
+		insertBatch, deleteBatch := writer.GenerateEntries(5000)
+		b.Logf("\ninsert batch size: %d\ndelete batch size: %d", insertBatch.Size(), deleteBatch.Size())
+	}
+	b.StopTimer()
 }

--- a/template/insert_template_test.go
+++ b/template/insert_template_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	database "github.com/Keith1039/dbvg/db"
 	"github.com/Keith1039/dbvg/graph"
-	"github.com/Keith1039/dbvg/parameters"
 	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/template"
 	"github.com/Keith1039/dbvg/utils"
@@ -28,8 +27,6 @@ var tableData map[string]map[string]string
 var requiredTables []string
 
 const path = "file://../db/migrations/"
-
-const realMigrationPath = "file://../db/real_migrations/"
 
 func drop() {
 	// drop the database
@@ -78,23 +75,6 @@ func buildUp(caseName string) error {
 	driver, err := postgres.WithInstance(db, &postgres.Config{})
 	m, err2 := migrate.NewWithDatabaseInstance(
 		path+caseName,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
-}
-
-func buildUpRealCase() error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		realMigrationPath,
 		"postgres", driver)
 	if m != nil {
 		err = m.Up()
@@ -441,22 +421,4 @@ func TestInsertTemplateDefaults(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-}
-
-func BenchmarkGenerateQueries(b *testing.B) {
-	drop()
-	err := buildUpRealCase()
-	if err != nil {
-		b.Fatal(err)
-	}
-	writer, err := parameters.NewQueryWriter(db, "purchases")
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
-	for range b.N {
-		insertBatch, deleteBatch := writer.GenerateEntries(5000)
-		b.Logf("\ninsert batch size: %d\ndelete batch size: %d", insertBatch.Size(), deleteBatch.Size())
-	}
-	b.StopTimer()
 }


### PR DESCRIPTION
This commit is about streamlining the process used to create queries and executing them. I previously used lists but that was unnecessary. I instead used arrays of fixed sizes since I know what the sizes should always be. This way I am space efficient.

## Other Changes:
- Added some docs for function
- Changed `RunUnsafeQueries()` to now have a verbose flag and thus removing `RunUnsafeQueriesVerbose()`
- Changed the way batches work so they now used arrays of fixed sizes
- Fixed some tests
- Moved `QueryWriter` benchmarking back to where it should be from `templates` package