### PR TITLE
Task 28: Introducing Time type & simplifications

### DIFF
--- a/db/README.md
+++ b/db/README.md
@@ -45,8 +45,8 @@ and `Strategy` support.
 - `TEXT` --> `VARCHAR`
 - `BOOL` --> `BOOL`
 - `DATE` --> `DATE`
-- `TIME` --> `DATE`
-- `TIMETZ` --> `DATE`
+- `TIME` --> `TIME`
+- `TIMETZ` --> `TIME`
 - `TIMESTAMP` --> `DATE`
 - `TIMESTAMPTZ` --> `DATE`
 

--- a/db/db.go
+++ b/db/db.go
@@ -46,10 +46,10 @@ var typeMap = map[string]string{
 	"TEXT":        "VARCHAR",
 	"BOOL":        "BOOL",
 	"DATE":        "DATE",
-	"TIME":        "DATE",
-	"TIMETZ":      "DATE",
 	"TIMESTAMP":   "DATE",
 	"TIMESTAMPTZ": "DATE",
+	"TIME":        "TIME",
+	"TIMETZ":      "TIME",
 }
 
 var supportedTypes = map[string]bool{
@@ -59,6 +59,7 @@ var supportedTypes = map[string]bool{
 	"VARCHAR": true,
 	"BOOL":    true,
 	"DATE":    true,
+	"TIME":    true,
 }
 
 func IsSupportedType(typeName string) bool {

--- a/db/migrations/code_test/omni_test.json
+++ b/db/migrations/code_test/omni_test.json
@@ -301,26 +301,26 @@
   },
   "time_now": {
    "code": "NOW",
-   "type": "DATE",
+   "type": "TIME",
    "value": null
   },
   "time_null": {
    "code": "NULL",
-   "type": "DATE",
+   "type": "TIME",
    "value": null
   },
   "time_random": {
    "code": "RANDOM",
-   "type": "DATE",
+   "type": "TIME",
    "value": [
-    "2020-01-01",
-    "2026-01-01"
+    "00:00:00",
+    "23:59:59"
    ]
   },
   "time_static": {
    "code": "STATIC",
-   "type": "DATE",
-   "value": "2014-07-19"
+   "type": "TIME",
+   "value": "01:20:00"
   },
   "timestamp_now": {
    "code": "NOW",
@@ -370,26 +370,26 @@
   },
   "timetz_now": {
    "code": "NOW",
-   "type": "DATE",
+   "type": "TIME",
    "value": null
   },
   "timetz_null": {
    "code": "NULL",
-   "type": "DATE",
+   "type": "TIME",
    "value": null
   },
   "timetz_random": {
    "code": "RANDOM",
-   "type": "DATE",
+   "type": "TIME",
    "value": [
-    "2014-01-01",
-    "2018-03-01"
+    "14:59:59",
+    "20:00:00"
    ]
   },
   "timetz_static": {
    "code": "STATIC",
-   "type": "DATE",
-   "value": "1999-10-10"
+   "type": "TIME",
+   "value": "14:14:09"
   },
   "uuid_null": {
    "code": "NULL",

--- a/strategy/Existing_Strategies.md
+++ b/strategy/Existing_Strategies.md
@@ -3,10 +3,7 @@
 ## Overview
 Each `Strategy` is supported by a specific type and a code. In other words, those are the keys for the `Strategy` in the internal maps.
 As such, each supported type will have a section and underneath their section will be a description of the Strategies supported for that type.
-
-
-## Special Case
-All types by default accept the `NULL` code.
+A special case is the `NULL` code. All types by default accept the `NULL` code.
 
 ## ALL
 ### NULL
@@ -16,7 +13,7 @@ All types by default accept the `NULL` code.
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "NULL",
     "value": [1, 10]
@@ -25,7 +22,7 @@ All types by default accept the `NULL` code.
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "NULL",
     "value": true
@@ -44,7 +41,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "RANDOM",
     "value": [1, 10]
@@ -55,7 +52,7 @@ N/A
 #### Invalid Examples
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "RANDOM",
     "value": [10, 5]
@@ -65,7 +62,7 @@ N/A
 
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "RANDOM",
     "value": "1-20"
@@ -80,7 +77,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "STATIC",
     "value": 5
@@ -91,7 +88,7 @@ N/A
 #### Invalid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "STATIC",
     "value": "5.0"
@@ -99,14 +96,14 @@ N/A
 }
 ```
 
-#### SERIAL
+### SERIAL
 #### Type: `Optional Strategy`
 #### Expected Value: null (defaults to 1) or any integer >= 1
 #### Behavior: Outputs the given integer and then increments the value by 1 for the next time the `Strategy` is executed
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "STATIC",
     "value": null
@@ -115,7 +112,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "STATIC",
     "value": 5
@@ -126,7 +123,7 @@ N/A
 #### Invalid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "STATIC",
     "value": 0
@@ -135,7 +132,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "INT",
     "code": "STATIC",
     "value": "6"
@@ -151,7 +148,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "RANDOM",
     "value": [1, 10]
@@ -162,7 +159,7 @@ N/A
 #### Invalid Examples
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "RANDOM",
     "value": [10, 5]
@@ -172,7 +169,7 @@ N/A
 
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "RANDOM",
     "value": "1.75-10.80"
@@ -187,7 +184,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "STATIC",
     "value": 5
@@ -196,7 +193,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "STATIC",
     "value": 20.34
@@ -206,7 +203,7 @@ N/A
 #### Invalid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "FLOAT",
     "code": "STATIC",
     "value": "54.76"
@@ -222,7 +219,7 @@ N/A
 #### Valid Examples:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "UUID",
     "code": "UUID",
     "value": [1, 20, 314]
@@ -231,7 +228,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "UUID",
     "code": "UUID",
     "value": true
@@ -241,7 +238,7 @@ N/A
 #### Invalid Examples:
 N/A
 
-## Bool
+## BOOL
 ### RANDOM
 #### Type: `Override Strategy`
 #### Expected Value: N/A
@@ -249,7 +246,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "BOOL",
     "code": "RANDOM",
     "value": "some string"
@@ -258,7 +255,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "BOOL",
     "code": "RANDOM",
     "value": true
@@ -275,7 +272,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "BOOL",
     "code": "STATIC",
     "value": true
@@ -284,7 +281,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "BOOL",
     "code": "STATIC",
     "value": false
@@ -294,7 +291,7 @@ N/A
 #### Invalid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "BOOL",
     "code": "STATIC",
     "value": "true"
@@ -303,7 +300,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "BOOL",
     "code": "STATIC",
     "value": null
@@ -316,18 +313,191 @@ N/A
 ### NOW
 #### Type: `Override Strategy`
 #### Expected Value: N/A
-#### Behavior: Outputs the current time as a `time.time` struct every time the `Strategy` is executed
+#### Behavior: Outputs the current time as a `time.Time` struct every time the `Strategy` is executed
 #### Valid Example:
-
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "NOW",
+    "value": null
+  }
+}
+```
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "NOW",
+    "value": 50
+  }
+}
+```
 #### Invalid Example:
 N/A
+
+### STATIC
+#### Type: `Required Strategy`
+#### Expected Value: valid date string
+#### Behavior: Outputs a `time.Time` struct with using the given date string every time the `Strategy` is executed
+#### Valid Example:
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "STATIC",
+    "value": "2009-11-10 23:00:00"
+  }
+}
+```
+#### Invalid Example
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "STATIC",
+    "value": 20221001
+  }
+}
+```
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "STATIC",
+    "value": "14-2020"
+  }
+}
+```
 
 ### RANDOM
 #### Type: `Required Strategy`
 #### Expected Value: [2]string with 2 valid date strings where string[0] < string[1]
-#### Behavior: Outputs a `time.time` struct with a date that's in the range of [ string[0], string[1] )
+#### Behavior: Outputs a `time.Time` struct with a date that's in the range of [ string[0], string[1] ) every time the `Strategy` is executed
+#### Valid Example:
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "RANDOM",
+    "value": ["2000-01-02", "2026-01-01"]
+  }
+}
+```
+#### Invalid Example:
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "RANDOM",
+    "value": true
+  }
+}
+```
+```json
+{
+  "column": {
+    "type": "DATE",
+    "code": "RANDOM",
+    "value": ["2026-01-01", "2000-01-02"]
+  }
+}
+```
+## TIME
 
+### NOW
+#### Type: `Override Strategy`
+#### Expected Value: N/A
+#### Behavior: Outputs the current time as a `time.Time` struct every time the `Strategy` is executed
+#### Valid Example:
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "NOW",
+    "value": null
+  }
+}
+```
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "NOW",
+    "value": 50
+  }
+}
+```
+#### Invalid Example:
+N/A
 
+### STATIC
+#### Type: `Required Strategy`
+#### Expected Value: valid time string of format (HH:MM:SS)
+#### Behavior: Outputs a `time.Time` struct with using the given time string every time the `Strategy` is executed
+#### Valid Example:
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "STATIC",
+    "value": "23:00:00"
+  }
+}
+```
+#### Invalid Example
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "STATIC",
+    "value": 230000
+  }
+}
+```
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "STATIC",
+    "value": "2009-11-10 23:00:00"
+  }
+}
+```
+
+### RANDOM
+#### Type: `Required Strategy`
+#### Expected Value: [2]string with 2 valid time (HH:MM:SS) strings where string[0] < string[1]
+#### Behavior: Outputs a `time.Time` struct with a time that's in the range of [ string[0], string[1] ) every time the `Strategy` is executed
+#### Valid Example:
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "RANDOM",
+    "value": ["00:00:00", "23:59:59"]
+  }
+}
+```
+#### Invalid Example
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "RANDOM",
+    "value": ["23:59:59", "00:00:00"]
+  }
+}
+```
+```json
+{
+  "column": {
+    "type": "TIME",
+    "code": "RANDOM",
+    "value": 500
+  }
+}
+```
 
 ## VARCHAR
 
@@ -338,7 +508,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "STATIC",
     "value": "gr(a|e)y" 
@@ -348,7 +518,7 @@ N/A
 #### Invalid Examples:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "STATIC",
     "value": "[aZ-Az]"
@@ -357,7 +527,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "STATIC",
     "value": null
@@ -372,7 +542,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "STATIC",
     "value": "some string"
@@ -382,7 +552,7 @@ N/A
 #### Invalid Examples:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "STATIC",
     "value": true
@@ -391,7 +561,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "STATIC",
     "value": null
@@ -406,7 +576,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "EMAIL",
     "value": null
@@ -415,7 +585,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "EMAIL",
     "value": true
@@ -432,7 +602,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "FIRSTNAME",
     "value": null
@@ -441,7 +611,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "FIRSTNAME",
     "value": 20
@@ -459,7 +629,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "LASTNAME",
     "value": null
@@ -468,7 +638,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "LASTNAME",
     "value": [1, ""]
@@ -485,7 +655,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "FULLNAME",
     "value": null
@@ -494,7 +664,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "FULLNAME",
     "value": [1,"", 1204]
@@ -511,7 +681,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "PHONE",
     "value": null
@@ -520,7 +690,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "PHONE",
     "value": "2026-01"
@@ -538,7 +708,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "COUNTRY",
     "value": null
@@ -547,7 +717,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "COUNTRY",
     "value": "Random Country Name"
@@ -564,7 +734,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "ADDRESS",
     "value": null
@@ -573,7 +743,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "ADDRESS",
     "value": "900 some address ave"
@@ -590,7 +760,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "ZIPCODE",
     "value": null
@@ -599,7 +769,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "ZIPCODE",
     "value": "1 + 2"
@@ -617,7 +787,7 @@ N/A
 #### Valid Example:
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "CITY",
     "value": null
@@ -626,7 +796,7 @@ N/A
 ```
 ```json
 {
-  "purchase": {
+  "column": {
     "type": "VARCHAR",
     "code": "CITY",
     "value": "Atl"

--- a/strategy/code_error.go
+++ b/strategy/code_error.go
@@ -66,11 +66,20 @@ func (e InvalidRegexError) Error() string {
 	return fmt.Sprintf("string '%s' is not proper regex, failed with %v", e.Regex, e.Err)
 }
 
-// ImproperDateStringFormatError is an error given when the given date string doesn't match the RFC3339
+// ImproperDateStringFormatError is an error given when the given date string doesn't match any known format
 type ImproperDateStringFormatError struct {
 	DateString string
 }
 
 func (e ImproperDateStringFormatError) Error() string {
 	return fmt.Sprintf("date string '%s' cannot be parsed via carbon", e.DateString)
+}
+
+// ImproperTimeStringFormatError is an error given when the given time string doesn't match the time.TimeOnly layout
+type ImproperTimeStringFormatError struct {
+	TimeString string
+}
+
+func (e ImproperTimeStringFormatError) Error() string {
+	return fmt.Sprintf("time string '%s' does not fit the layout of 'HH:MM:SS' or was beyond the acceptable range of '00:00:00' - '23:59:59'", e.TimeString)
 }

--- a/strategy/globals.go
+++ b/strategy/globals.go
@@ -17,6 +17,11 @@ var defaults = map[string]map[string]bool{
 		"RANDOM": true,
 		"STATIC": true,
 	},
+	"TIME": {
+		"NOW":    true,
+		"RANDOM": true,
+		"STATIC": true,
+	},
 	"UUID": {"UUID": true},
 	"BOOL": {
 		"RANDOM": true,
@@ -52,7 +57,8 @@ func makeCopyAndReturn[T factories](m map[string]map[string]T) map[string]map[st
 }
 
 var overrideCodeMap = map[string]map[string]func() Strategy{
-	"DATE": {"NOW": NewNowStrategy},
+	"DATE": {"NOW": NewNowDateStrategy},
+	"TIME": {"NOW": NewNowTimeStrategy}, // db handles getting only the time part of time stamp
 	"UUID": {"UUID": NewUUIDStrategy},
 	"BOOL": {"RANDOM": NewRandomBoolStrategy},
 	"VARCHAR": {
@@ -89,6 +95,10 @@ var requiredCodeMap = map[string]map[string]func() ValueStrategy{
 	"DATE": {
 		"RANDOM": NewRandomDateStrategy,
 		"STATIC": NewStaticDateStrategy,
+	},
+	"TIME": {
+		"RANDOM": NewRandomTimeStrategy,
+		"STATIC": NewStaticTimeStrategy,
 	},
 	"INT": {
 		"RANDOM": NewRandomIntStrategy,
@@ -129,7 +139,7 @@ func DeleteStrategy(columnType, codeName string) error {
 	}
 	s, _ := GetStrategy(columnType, codeName) // we don't care if there's an error, we care that we got a strategy
 	if s != nil {
-		if _, ok := defaults[columnType][codeName]; ok {
+		if ok := defaults[columnType][codeName]; ok {
 			return DeleteDefaultError{columnType: columnType, code: codeName}
 		} else {
 			// literally has to be one of these, if not it would return nil
@@ -163,12 +173,7 @@ func GetStrategy(columnType, codeName string) (Strategy, error) {
 	}
 	codeName = utils.TrimAndUpperString(codeName)
 	if codeName == "NULL" {
-		switch columnType {
-		case "UUID":
-			return NewNullUUIDStrategy(), nil
-		default:
-			return NewNullStrategy(), nil
-		}
+		return NewNullStrategy(), nil
 	}
 
 	strategy, ok := overrideCodeMap[columnType][codeName]

--- a/strategy/globals_test.go
+++ b/strategy/globals_test.go
@@ -17,7 +17,7 @@ func attemptDeletionForMap[T factories](m map[string]map[string]T) error {
 		for code, _ := range values {
 			err = strategy.DeleteStrategy(columnType, code)
 			if err == nil {
-				return errors.New(fmt.Sprintf("sucessfully deleated a default, columnType: '%s', code: '%s'", columnType, code))
+				return errors.New(fmt.Sprintf("sucessfully deleted a default, columnType: '%s', code: '%s'", columnType, code))
 			}
 		}
 	}
@@ -57,32 +57,21 @@ func TestDeleteStrategy(t *testing.T) {
 }
 
 func TestGetStrategy(t *testing.T) {
-	s, err := strategy.GetStrategy("", "")
+	_, err := strategy.GetStrategy("", "")
 	if err == nil {
 		t.Fatalf("expected error for unsupported column type")
 	}
-	s, err = strategy.GetStrategy("int", "asddfaafaffd")
+	_, err = strategy.GetStrategy("int", "asddfaafaffd")
 	if !errors.As(err, &strategy.UnsupportedCodeError{}) {
 		t.Fatalf("expected 'UnsupportedCodeError' but received %v", err)
 	}
-	s, err = strategy.GetStrategy("          int        ", " random       ")
+	_, err = strategy.GetStrategy("          int        ", " random       ")
 	if err != nil {
 		t.Fatalf("expected no error but received %v", err)
 	}
-	s, err = strategy.GetStrategy("int", "null")
+	_, err = strategy.GetStrategy("int", "null")
 	if err != nil {
 		t.Fatalf("expected no error but received %v", err)
-	}
-	genericStrat := s.(*strategy.OverrideStrategy).Strategy
-	s, err = strategy.GetStrategy("uuid", "null")
-	if err != nil {
-		t.Fatalf("expected no error but received %v", err)
-	}
-	uuidSpecificStrat := s.(*strategy.OverrideStrategy).Strategy
-	val1, _ := genericStrat()
-	val2, _ := uuidSpecificStrat()
-	if val1 == val2 {
-		t.Fatal("generic Null strategy should not return the same as uuid's Null strategy")
 	}
 }
 

--- a/strategy/override.go
+++ b/strategy/override.go
@@ -42,21 +42,17 @@ func NewNullStrategy() Strategy {
 	return &OverrideStrategy{Strategy: handleNullCode}
 }
 
-func handleNullCodeUUID() (any, error) {
-	return uuid.Nil.String(), nil
-}
-
-// NewNullUUIDStrategy defines and returns a Strategy of type OverrideStrategy meant to handle the "NUll" code for type "UUID"
-func NewNullUUIDStrategy() Strategy {
-	return &OverrideStrategy{Strategy: handleNullCodeUUID}
-}
-
 func handleNowCode() (any, error) {
-	return time.Now().String()[0:19], nil
+	return time.Now(), nil
 }
 
-// NewNowStrategy defines and returns a Strategy of type OverrideStrategy meant to handle code "NOW" for type "DATE"
-func NewNowStrategy() Strategy {
+// NewNowDateStrategy defines and returns a Strategy of type OverrideStrategy meant to handle code "NOW" for type "DATE"
+func NewNowDateStrategy() Strategy {
+	return &OverrideStrategy{Strategy: handleNowCode}
+}
+
+// NewNowTimeStrategy defines and returns a Strategy of type OverrideStrategy meant to handle code "NOW" for type "TIME"
+func NewNowTimeStrategy() Strategy {
 	return &OverrideStrategy{Strategy: handleNowCode}
 }
 

--- a/strategy/override_test.go
+++ b/strategy/override_test.go
@@ -3,7 +3,6 @@ package strategy
 import (
 	"fmt"
 	"github.com/Keith1039/dbvg/utils"
-	"github.com/google/uuid"
 	"testing"
 )
 
@@ -13,7 +12,8 @@ func implementsValueStrategy(s Strategy) bool {
 }
 
 var overrideExpectMap = map[string]string{
-	"DATE":    "string",
+	"TIME":    "time.Time",
+	"DATE":    "time.Time",
 	"UUID":    "string",
 	"BOOL":    "bool",
 	"VARCHAR": "string",
@@ -47,28 +47,6 @@ func TestOverrideStrategy_Null(t *testing.T) {
 
 	if res != nil {
 		t.Fatal(UnexpectedTypeError{ExpectedType: "nil", ActualType: fmt.Sprintf("%T", res)})
-	}
-
-	uuidNullStrategy, err := GetStrategy("uuid", "null")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if implementsValueStrategy(uuidNullStrategy) {
-		t.Fatal(ValueStrategyImplementedError{})
-	}
-
-	res, err = uuidNullStrategy.ExecuteStrategy()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	val, ok := res.(string)
-	if !ok {
-		t.Fatal(UnexpectedTypeError{ExpectedType: "string", ActualType: fmt.Sprintf("%T", res)})
-	}
-	uuidNull := uuid.Nil.String()
-	if val != uuidNull {
-		t.Fatalf("expected value '%s', actual value '%s'", uuidNull, val)
 	}
 }
 

--- a/strategy/required.go
+++ b/strategy/required.go
@@ -8,6 +8,7 @@ import (
 	regen "github.com/zach-klippenstein/goregen"
 	"math/rand/v2"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -174,9 +175,21 @@ func staticDateCriteria(val any) error {
 	}
 }
 
+func staticDateStrategy(val any) (any, error) {
+	v, ok := val.(string)
+	if !ok {
+		return nil, UnexpectedTypeError{ExpectedType: "string", ActualType: v}
+	}
+	c := carbon.Parse(v)
+	if c.Error != nil {
+		return nil, ImproperDateStringFormatError{DateString: v}
+	}
+	return c.ToStdTime(), nil
+}
+
 // NewStaticDateStrategy defines and returns a Strategy of type RequiredStrategy meant to handle code "STATIC" for type "DATE"
 func NewStaticDateStrategy() ValueStrategy {
-	return &RequiredStrategy{defaultStrategy: &defaultStrategy{Strategy: staticStrategy, Criteria: staticDateCriteria}}
+	return &RequiredStrategy{defaultStrategy: &defaultStrategy{Strategy: staticDateStrategy, Criteria: staticDateCriteria}}
 }
 
 func randomDateCriteria(val any) error {
@@ -219,7 +232,7 @@ func randomDateStrategy(val any) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	return carbon.Parse(date).ToString(), nil
+	return carbon.Parse(date).ToStdTime(), nil
 }
 
 // NewRandomDateStrategy defines and returns a Strategy of type RequiredStrategy meant to handle code "RANDOM" for type "DATE"
@@ -227,4 +240,79 @@ func NewRandomDateStrategy() ValueStrategy {
 	return &RequiredStrategy{defaultStrategy: &defaultStrategy{Strategy: randomDateStrategy, Criteria: randomDateCriteria}}
 }
 
-//
+// Time type
+
+func staticTimeCriteria(val any) error {
+	switch t := val.(type) {
+	case string:
+		t = strings.TrimSpace(t)
+		_, err := time.Parse(time.TimeOnly, t)
+		if err != nil {
+			return ImproperTimeStringFormatError{TimeString: t}
+		}
+		return nil
+	default:
+		return UnexpectedTypeError{ExpectedType: "string", ActualType: utils.GetStringType(t)}
+	}
+}
+
+func staticTimeStrategy(val any) (any, error) {
+	timeString := val.(string)
+	t, err := time.Parse(time.TimeOnly, timeString)
+	if err != nil {
+		return nil, ImproperTimeStringFormatError{TimeString: timeString}
+	}
+	return t, nil
+}
+
+// NewStaticTimeStrategy defines and returns a Strategy of type RequiredStrategy meant to handle code "STATIC" for type "TIME"
+func NewStaticTimeStrategy() ValueStrategy {
+	return &RequiredStrategy{defaultStrategy: &defaultStrategy{Strategy: staticTimeStrategy, Criteria: staticTimeCriteria}}
+}
+
+func randomTimeCriteria(val any) error {
+	switch t := val.(type) {
+	case []string:
+		if len(t) == 2 {
+			t[0] = strings.TrimSpace(t[0])
+			t[1] = strings.TrimSpace(t[1])
+			t1, err := time.Parse(time.TimeOnly, t[0])
+			if err != nil {
+				return ImproperTimeStringFormatError{TimeString: t[0]}
+			}
+			t2, err := time.Parse(time.TimeOnly, t[1])
+			if err != nil {
+				return ImproperTimeStringFormatError{TimeString: t[1]}
+			}
+			if t1.After(t2) { // check to see if the bound works
+				return RandomBoundError{LowerBound: t[0], UpperBound: t[1]}
+			}
+			return nil
+		} else {
+			return UnexpectedArrayLengthError{ExpectedLength: 2, ActualLength: len(t)}
+		}
+	default:
+		return UnexpectedTypeError{ExpectedType: "[]string", ActualType: fmt.Sprintf("%T", t)}
+	}
+}
+
+func randomTimeStrategy(val any) (any, error) {
+	t1, err := time.Parse(time.TimeOnly, "12:00:00")
+	if err != nil {
+		return nil, err
+	}
+	t2, err := time.Parse(time.TimeOnly, "23:00:00")
+	if err != nil {
+		return nil, err
+	}
+	duration := t2.Sub(t1)
+	r := int64(duration / time.Second) // the range between the 2 times as an int
+	num := rand.N(r)
+	t3 := t1.Add(time.Duration(num) * time.Second)
+	return t3, nil
+}
+
+// NewRandomTimeStrategy defines and returns a Strategy of type RequiredStrategy meant to handle code "RANDOM" for type "TIME"
+func NewRandomTimeStrategy() ValueStrategy {
+	return &RequiredStrategy{defaultStrategy: &defaultStrategy{Strategy: randomTimeStrategy, Criteria: randomTimeCriteria}}
+}

--- a/strategy/required_test.go
+++ b/strategy/required_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang-module/carbon"
 	"regexp"
 	"testing"
+	"time"
 )
 
 type expectedValueError struct {
@@ -57,9 +58,9 @@ func dateRandomTestRunner() *testRunner {
 		arr := s.Value.([]string)
 		t1, _ := utils.GetTimeFromString(arr[0])
 		t2, _ := utils.GetTimeFromString(arr[1])
-		t3, err := utils.GetTimeFromString(val.(string))
-		if err != nil {
-			return err
+		t3, ok := val.(time.Time)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "time.Time", ActualType: utils.GetStringType(val)}
 		}
 		if t3.Before(t1) || t3.After(t2) {
 			return errors.New(fmt.Sprintf("generated value '%v' is out of bounds of value '%v", t3, arr))
@@ -80,9 +81,54 @@ func dateStaticTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		return staticEvaluator(val, s.Value)
+		return staticEvaluator(val, carbon.Parse(s.Value.(string)).ToStdTime())
 	}
 
+	return &t
+}
+
+func timeStaticTestRunner() *testRunner {
+	t := testRunner{
+		testValues:     []any{false, "24:00:00", "22:00:00"},
+		expectedErrors: []error{strategy.UnexpectedTypeError{}, strategy.ImproperTimeStringFormatError{}},
+	}
+
+	t.evalCriteria = func(val any) error {
+		s, ok := t.strategy.(*strategy.RequiredStrategy)
+		if !ok {
+			return errors.New("strategy could not be cast to 'RequiredStrategy'")
+		}
+		return staticEvaluator(val, carbon.Parse(s.Value.(string)).ToStdTime())
+	}
+
+	return &t
+}
+
+func timeRandomTestRunner() *testRunner {
+	t := testRunner{
+		testValues: []any{"", []string{"", "", ""}, []string{"03-01-2025", "2025-01-02"},
+			[]string{"00:00:00", "24:00:00"}, []string{"13:00:00", "00:00:00"},
+			[]string{"00:00:00", "23:00:00"}},
+		expectedErrors: []error{strategy.UnexpectedTypeError{}, strategy.UnexpectedArrayLengthError{}, strategy.ImproperTimeStringFormatError{},
+			strategy.ImproperTimeStringFormatError{}, strategy.RandomBoundError{}},
+	}
+	t.evalCriteria = func(val any) error {
+		s, ok := t.strategy.(*strategy.RequiredStrategy)
+		if !ok {
+			return errors.New("strategy could not be cast to 'RequiredStrategy'")
+		}
+		arr := s.Value.([]string)
+		t1, _ := utils.GetTimeFromString(arr[0])
+		t2, _ := utils.GetTimeFromString(arr[1])
+		t3, ok := val.(time.Time)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "time.Time", ActualType: utils.GetStringType(val)}
+		}
+		if t3.Before(t1) || t3.After(t2) {
+			return errors.New(fmt.Sprintf("generated value '%v' is out of bounds of value '%v", t3, arr))
+		}
+		return nil
+	}
 	return &t
 }
 

--- a/template/defaults.go
+++ b/template/defaults.go
@@ -8,7 +8,8 @@ var defaults = map[string]func() strategy.Strategy{
 	"INT":     func() strategy.Strategy { return defaultSerial() },
 	"FLOAT":   defaultFloatRandom,
 	"UUID":    func() strategy.Strategy { return strategy.NewUUIDStrategy() },
-	"DATE":    func() strategy.Strategy { return strategy.NewNowStrategy() },
+	"DATE":    func() strategy.Strategy { return strategy.NewNowDateStrategy() },
+	"TIME":    func() strategy.Strategy { return strategy.NewNowTimeStrategy() },
 	"BOOL":    func() strategy.Strategy { return strategy.NewRandomBoolStrategy() },
 	"VARCHAR": defaultRegex,
 }
@@ -18,6 +19,7 @@ var defaultCode = map[string]string{
 	"FLOAT":   "RANDOM",
 	"UUID":    "UUID",
 	"DATE":    "NOW",
+	"TIME":    "NOW",
 	"BOOL":    "RANDOM",
 	"VARCHAR": "REGEX",
 }

--- a/template/preproccess.go
+++ b/template/preproccess.go
@@ -16,7 +16,7 @@ func preprocess(val *any, columnType string) error {
 		}
 	case []interface{}:
 		// check if this is string
-		if (columnType == "VARCHAR" || columnType == "DATE") && checkForTypeHomogeny(*val, "string") { // check if it's a string arr
+		if (columnType == "VARCHAR" || columnType == "DATE" || columnType == "TIME") && checkForTypeHomogeny(*val, "string") { // check if it's a string arr
 			convertToStringArray(val) // convert it to []string under the hood
 		} else if columnType == "INT" && checkIfNumericArray(*val) { // check if it's a numeric array
 			convertToIntArray(val) // convert it to []int under the hood


### PR DESCRIPTION
This commit adds some changes to the supported types. The new `TIME` type is meant to represent both `TIME` and `TIMETZ` in postgres. The necessary changes were made to accommodate this new addition including the proper strategies and testing.

This series of changes also fixed `DATE` strategies. Errors occurred because they weren't returning `time.Time` objects. This made it so that I would manually have to ensure the correct format for each type. Rather than do that, I would much rather let the DB do that for me, as such, going forward, each `TIME` and `DATE` strategy must return `time.Time`.

Other Changes:
- Docs were updated to reflect these changes
- UUID no longer has a unique `NULL` code `Strategy` it just uses the generic one
- Renamed some strategies to indicate the type they belong to in the case of `DATE` and `TIME` even if they use the same underlying criteria's and strategy
- updated omni template