### PR TITLE
Task 29: Introducing Docker and DB test library

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ https://github.com/Keith1039/dbvg/releases
 Antivirus' on Windows sometimes flag Golang compiled executables as malware.
 This is shown [here](https://go.dev/doc/faq#virus).
 
+## Testing
+To run the tests for this project, you first need to start the DB using:
+```shell
+docker-compose up
+```
+
+All the tests reference this database and will fail without it. Once the database is up and running, you can then run the go CLI.
+```shell
+go test -v ./...
+```
+ 
 ## Main Offering
 dbvg provides tools to detect/resolve cycles in a database schema
 as well as generate a variable amount of table entries while maintaining

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -4,97 +4,38 @@ import (
 	"database/sql"
 	"fmt"
 	database "github.com/Keith1039/dbvg/db"
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
-	"log"
+	"github.com/peterldowns/pgtestdb"
+	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"maps"
-	"os"
 	"slices"
 	"testing"
 	"time"
 )
 
-const path = "file://../db/migrations/"
-
-const realMigrationPath = "file://../db/real_migrations/"
-
 var db *sql.DB
 
-func drop() {
-	// drop the database
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path+"case1",
-		"postgres", driver)
-	if m != nil {
-		err = m.Drop()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		log.Fatal(err2)
-	}
-}
+var pgConf pgtestdb.Config
 
-func buildUp(caseName string) error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path+caseName,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
-}
-
-func buildUpRealCase() error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		realMigrationPath,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
-}
+var migrator pgtestdb.Migrator
 
 func init() {
-	var err error
-	err = os.Setenv("DATABASE_URL", "postgres://postgres:localDB12@localhost:5432/testgres?sslmode=disable")
-	if err != nil {
-		log.Fatal(err)
+	pgConf = pgtestdb.Config{
+		DriverName: "postgres", // uses the lib/pq driver
+		//Database:   "postgres",
+		User:     "postgres",
+		Password: "password",
+		Host:     "localhost",
+		Port:     "2000",
+		Options:  "sslmode=disable",
 	}
-	db, err = sql.Open("postgres", os.Getenv("DATABASE_URL"))
-	if err != nil {
-		panic(err)
-	}
-	drop()
 }
 
 func TestGetTableMap(t *testing.T) {
-	drop()
-	err := buildUp("case5")
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("migrations/case5")
+	db = pgtestdb.New(t, pgConf, migrator)
 	expectedMap := map[string]int{
 		"a": 1,
 		"b": 1,
@@ -111,11 +52,8 @@ func TestGetTableMap(t *testing.T) {
 }
 
 func TestGetColumnMap(t *testing.T) {
-	drop()
-	err := buildUpRealCase()
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("real_migrations/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	expectedMap := map[string]string{
 		"user_id":    "UUID",
 		"product_id": "UUID",
@@ -130,11 +68,8 @@ func TestGetColumnMap(t *testing.T) {
 }
 
 func TestGetAllColumnData(t *testing.T) {
-	drop()
-	err := buildUpRealCase()
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("real_migrations/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	expectedMap := map[string]map[string]string{
 		"users": {
 			"id":         "UUID",
@@ -179,11 +114,8 @@ func TestGetAllColumnData(t *testing.T) {
 }
 
 func TestGetRawColumnMap(t *testing.T) {
-	drop()
-	err := buildUpRealCase()
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("real_migrations/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	validateMap := map[string]string{
 		"id":          "UUID",
 		"company_id":  "UUID",
@@ -206,11 +138,8 @@ func TestGetRawColumnMap(t *testing.T) {
 }
 
 func TestGetTablePKMap(t *testing.T) {
-	drop()
-	err := buildUp("case8")
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("migrations/case8/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	expectedMap := map[string][]string{
 		"a": {"akey"},
 		"b": {"bkey", "bkey2"},
@@ -231,11 +160,8 @@ func TestGetTablePKMap(t *testing.T) {
 }
 
 func TestGetRelationships(t *testing.T) {
-	drop()
-	err := buildUp("case9")
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("migrations/case9/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	expectedMap := map[string]map[string]map[string]string{
 		"a": {
 			"bkey": {
@@ -331,11 +257,8 @@ func TestGetRelationships(t *testing.T) {
 }
 
 func TestGetInverseRelationships(t *testing.T) {
-	drop()
-	err := buildUp("case9")
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("migrations/case9/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	expectedMap := map[string]map[string]bool{
 		"a": {
 			"c": true,
@@ -388,16 +311,13 @@ func TestGetInverseRelationships(t *testing.T) {
 }
 
 func TestRunUnsafeQueries(t *testing.T) {
-	drop()
-	err := buildUpRealCase()
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New("real_migrations/")
+	db = pgtestdb.New(t, pgConf, migrator)
 	queries := []string{
 		fmt.Sprintf("INSERT INTO USERS(ID, FIRST_NAME, LAST_NAME, EMAIL, ADDRESS, CREATED_AT) VALUES ('%v', '%v', '%v', '%v', '%v', '%v')", uuid.New(), "some", "name", "test@gmail.com", "SOMETHING", time.Now().Format("2006-01-02 15:04:05")),
 		fmt.Sprintf("INSERT INTO USERS(ID, FIRST_NAME, LAST_NAME, EMAIL, ADDRESS, CREATED_AT) VALUES ('%v', '%v', '%v', '%v', '%v', '%v')", uuid.New(), "some", "name", "test2@gmail.com", "SOMETHING", time.Now().Format("2006-01-02 15:04:05")),
 	}
-	err = database.RunUnsafeQueries(db, queries, false)
+	err := database.RunUnsafeQueries(db, queries, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+services:
+  pgtestdb:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: "password"
+    restart: unless-stopped
+    volumes:
+      # Uses a tmpfs volume to make tests extremely fast. The data in test
+      # databases is not persisted across restarts, nor does it need to be.
+      - type: tmpfs
+        target: /var/lib/postgresql/data/
+    command:
+      - "postgres"
+      - "-c" # turn off fsync for speed
+      - "fsync=off"
+      - "-c" # log everything for debugging
+      - "log_statement=all"
+    ports:
+      # Entirely up to you what port you want to use while testing.
+      - "2000:5432"

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,12 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/golang-module/carbon v1.7.3
 	github.com/google/uuid v1.6.0
+	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jimsmart/schema v0.2.1
 	github.com/lib/pq v1.10.9
 	github.com/spf13/cobra v1.8.1
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
-	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0
+	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
 )
 
 require (
@@ -24,12 +25,20 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/peterldowns/pgtestdb v0.1.1 // indirect
+	github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/smartystreets/goconvey v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
+	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
+	golang.org/x/sync v0.8.0 // indirect
+	golang.org/x/text v0.18.0 // indirect
 )
 
 replace github.com/golang-module/carbon v1.7.3 => github.com/dromara/carbon v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,14 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.7.1 h1:x7SYsPBYDkHDksogeSmZZ5xzThcTgRz++I5E+ePFUcs=
+github.com/jackc/pgx/v5 v5.7.1/go.mod h1:e7O26IywZZ+naJtWWos6i6fvWK+29etgITqrqHLfoZA=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jimsmart/schema v0.2.1 h1:MsSsqq0i86bUskhJJZ6RnrgscbDeBMalLZym6Hx9l3U=
 github.com/jimsmart/schema v0.2.1/go.mod h1:4O5InKFd6Fv1xsegHVRLW/Zzm6U2iOqfE8PaI/f+wMU=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -171,6 +179,10 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterldowns/pgtestdb v0.1.1 h1:+hBCD1DcbKeg5Sfg0G+5WNIy/Cm0ORgwMkF4ygihrmU=
+github.com/peterldowns/pgtestdb v0.1.1/go.mod h1:yVWInWV0dxvmLdL2ao3nXDzWZ9+G6EhJ4gRwvI1Ozeg=
+github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1 h1:Pe/BsN5eAW+vEpKY0sRW+KqCqG3hXL/MLUfPE2rA4Ak=
+github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1/go.mod h1:q7UGHmppllfXsin8GgnOalCEe9VZgXjzQzOjITupN8E=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -239,8 +251,8 @@ golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/crypto v0.27.0 h1:GXm2NjJrPaiv/h1tb2UH8QfgC/hOf/+z0p6PT8o1w7A=
 golang.org/x/crypto v0.27.0/go.mod h1:1Xngt8kV6Dvbssa53Ziq6Eqn0HqbZi5Z6R0ZpwQzt70=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 h1:pVgRXcIictcr+lBQIFeiwuwtDIs4eL21OuM9nyAADmo=
-golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 h1:aAcj0Da7eBAtrTp03QXWvm88pSyOt+UgdZw2BFZ+lEw=
+golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8/go.mod h1:CQ1k9gNrJ50XIzaKCRR2hssIjF07kZFEiieALBM/ARQ=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -276,6 +288,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/graph/ordering_test.go
+++ b/graph/ordering_test.go
@@ -4,79 +4,40 @@ import (
 	"database/sql"
 	"errors"
 	"github.com/Keith1039/dbvg/graph"
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/lib/pq"
-	"log"
-	"os"
+	"github.com/peterldowns/pgtestdb"
+	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"strings"
 	"testing"
 )
 
 var db *sql.DB
 
-const path = "file://../db/migrations/"
+var pgConf pgtestdb.Config
 
-func drop() {
-	// drop the database
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path+"case1",
-		"postgres", driver)
-	if m != nil {
-		err = m.Drop()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		log.Fatal(err2)
-	}
-}
+var migrator pgtestdb.Migrator
+
+var migrationDir = "../db/migrations/"
 
 func init() {
-	var err error
-	err = os.Setenv("DATABASE_URL", "postgres://postgres:localDB12@localhost:5432/testgres?sslmode=disable")
-	if err != nil {
-		log.Fatal(err)
+	pgConf = pgtestdb.Config{
+		DriverName: "postgres", // uses the lib/pq driver
+		//Database:   "postgres",
+		User:     "postgres",
+		Password: "password",
+		Host:     "localhost",
+		Port:     "2000",
+		Options:  "sslmode=disable",
 	}
-	db, err = sql.Open("postgres", os.Getenv("DATABASE_URL"))
-	if err != nil {
-		panic(err)
-	}
-	drop() // drop the database
-}
-
-func buildUp(caseName string) error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path+caseName,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
 }
 
 func TestOrdering_FindOrderCase1(t *testing.T) {
 	// case where something on level 2 is moved down to level 4
-	defer drop()
-	caseName := "case1"
-	err := buildUp(caseName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New(migrationDir + "case1")
+	db = pgtestdb.New(t, pgConf, migrator)
 	ordering := graph.Ordering{}
-	err = ordering.Init(db)
+	err := ordering.Init(db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,15 +62,10 @@ func TestOrdering_FindOrderCase1(t *testing.T) {
 
 func TestOrdering_FindOrderCase2(t *testing.T) {
 	// case where there's a cyclic dependency
-	defer drop()
-	caseName := "case2"
-	err := buildUp(caseName)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	migrator = golangmigrator.New(migrationDir + "case2")
+	db = pgtestdb.New(t, pgConf, migrator)
 	ordering := graph.Ordering{}
-	err = ordering.Init(db)
+	err := ordering.Init(db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,15 +78,11 @@ func TestOrdering_FindOrderCase2(t *testing.T) {
 
 func TestOrdering_FindOrderCase3(t *testing.T) {
 	// give the function a table with no relationships
-	defer drop()
-	caseName := "case3"
-	err := buildUp(caseName)
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New(migrationDir + "case3")
+	db = pgtestdb.New(t, pgConf, migrator)
 
 	ordering := graph.Ordering{}
-	err = ordering.Init(db)
+	err := ordering.Init(db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,14 +95,10 @@ func TestOrdering_FindOrderCase3(t *testing.T) {
 }
 
 func TestOrdering_FindOrderCase4(t *testing.T) {
-	defer drop()
-	caseName := "case4"
-	err := buildUp(caseName)
-	if err != nil {
-		t.Fatal("Error should have been given")
-	}
+	migrator = golangmigrator.New(migrationDir + "case4")
+	db = pgtestdb.New(t, pgConf, migrator)
 	ordering := graph.Ordering{}
-	err = ordering.Init(db)
+	err := ordering.Init(db)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/parameters/batch_test.go
+++ b/parameters/batch_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/Keith1039/dbvg/graph"
 	"github.com/Keith1039/dbvg/parameters"
 	"github.com/Keith1039/dbvg/utils"
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/google/uuid"
 	_ "github.com/lib/pq"
+	"github.com/peterldowns/pgtestdb"
+	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"log"
 	"os"
 	"testing"
@@ -21,65 +21,23 @@ import (
 
 var db *sql.DB
 
-const path = "file://../db/real_migrations/"
+var pgConf pgtestdb.Config
 
-var batchWriter *parameters.QueryWriter
+var migrator pgtestdb.Migrator
 
-func drop() {
-	// drop the database
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path,
-		"postgres", driver)
-	if m != nil {
-		err = m.Drop()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		log.Fatal(err2)
-	}
-}
+const realMigrationDir = "../db/real_migrations/"
 
 func init() {
-	var err error
-	err = os.Setenv("DATABASE_URL", "postgres://postgres:localDB12@localhost:5432/testgres?sslmode=disable")
-	if err != nil {
-		log.Fatal(err)
+	pgConf = pgtestdb.Config{
+		DriverName: "postgres", // uses the lib/pq driver
+		//Database:   "postgres",
+		User:     "postgres",
+		Password: "password",
+		Host:     "localhost",
+		Port:     "2000",
+		Options:  "sslmode=disable",
 	}
-	db, err = sql.Open("postgres", os.Getenv("DATABASE_URL"))
-	if err != nil {
-		panic(err)
-	}
-	drop()          // drop the database
-	err = buildUp() // build up
-	if err != nil {
-		log.Fatal(err)
-	}
-	batchWriter, err = parameters.NewQueryWriter(db, "purchases")
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
-func buildUp() error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
+	migrator = golangmigrator.New(realMigrationDir)
 }
 
 func checkCountForTable(db *sql.DB, tableName string, expected int) error {
@@ -114,12 +72,13 @@ func writeMapToJSONFile(filePath string, data map[string]map[string]map[string]a
 }
 
 func TestQueryBatch_Exec(t *testing.T) {
-	drop()
-	err := buildUp() // build up
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
+	_, err := db.Exec("INSERT INTO COMPANIES(ID, NAME, EMAIL, CREATED_AT) VALUES($1, $2, $3, $4)", uuid.New(), "test", "some@email.com", time.Now())
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
-	_, err = db.Exec("INSERT INTO COMPANIES(ID, NAME, EMAIL, CREATED_AT) VALUES($1, $2, $3, $4)", uuid.New(), "test", "some@email.com", time.Now())
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,11 +102,8 @@ func TestQueryBatch_Exec(t *testing.T) {
 }
 
 func TestQueryBatch_ExecRollback(t *testing.T) {
-	drop()
-	err := buildUp() // build up
-	if err != nil {
-		log.Fatal(err)
-	}
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
 	dir := t.TempDir()
 	f, err := os.CreateTemp(dir, "")
 	if err != nil {
@@ -166,6 +122,10 @@ func TestQueryBatch_ExecRollback(t *testing.T) {
 	template["users"]["email"]["code"] = "STATIC"
 	template["users"]["email"]["value"] = "GonnaFail"
 	err = writeMapToJSONFile(f.Name(), template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,13 +150,14 @@ func TestQueryBatch_ExecRollback(t *testing.T) {
 }
 
 func TestQueryBatch_ExecContext(t *testing.T) {
-	drop()
-	err := buildUp()
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 	insertBatch, _ := batchWriter.GenerateEntries(5000)
 	err = insertBatch.ExecContext(ctx, db, false)
 	if err == nil {
@@ -208,11 +169,50 @@ func TestQueryBatch_ExecContext(t *testing.T) {
 	}
 }
 
-func Benchmark_ExecInsert(b *testing.B) {
-	drop()
-	err := buildUp()
+// tests the migration with every possible supported type and code with their defaults
+func TestQueryBatch_OmniCodeTestDefault(t *testing.T) {
+	migrator = golangmigrator.New(migrationDir + "code_test")
+	db = pgtestdb.New(t, pgConf, migrator)
+	batchWriter, err := parameters.NewQueryWriter(db, "test")
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
+	}
+	insertBatch, deleteBatch := batchWriter.GenerateEntries(500)
+	err = insertBatch.Exec(db, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = deleteBatch.Exec(db, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// tests the migration with every possible supported type and code with their template values
+func TestQueryBatch_OmniCodeTestWithTemplate(t *testing.T) {
+	migrator = golangmigrator.New(migrationDir + "code_test")
+	db = pgtestdb.New(t, pgConf, migrator)
+	batchWriter, err := parameters.NewQueryWriterWithTemplate(db, "test", migrationDir+"code_test/omni_test.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertBatch, deleteBatch := batchWriter.GenerateEntries(500)
+	err = insertBatch.Exec(db, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = deleteBatch.Exec(db, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func Benchmark_ExecInsert(b *testing.B) {
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(b, pgConf, migrator)
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
+	if err != nil {
+		b.Fatal(err)
 	}
 	insertBatch, deleteBatch := batchWriter.GenerateEntries(5000)
 	b.ResetTimer()
@@ -232,10 +232,11 @@ func Benchmark_ExecInsert(b *testing.B) {
 }
 
 func Benchmark_ExecDelete(b *testing.B) {
-	drop()
-	err := buildUp()
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(b, pgConf, migrator)
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
-		log.Fatal(err)
+		b.Fatal(err)
 	}
 	insertBatch, deleteBatch := batchWriter.GenerateEntries(5000)
 	b.ResetTimer()

--- a/parameters/query_writer_test.go
+++ b/parameters/query_writer_test.go
@@ -2,58 +2,33 @@ package parameters_test
 
 import (
 	"github.com/Keith1039/dbvg/parameters"
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/lib/pq"
+	"github.com/peterldowns/pgtestdb"
+	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"testing"
 )
 
-const realMigrationPath = "file://../db/real_migrations/"
+const migrationDir = "../db/migrations/"
 
-func buildUpCase(caseName string) error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		"file://../db/migrations/"+caseName,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
+func init() {
+	pgConf = pgtestdb.Config{
+		DriverName: "postgres", // uses the lib/pq driver
+		//Database:   "postgres",
+		User:     "postgres",
+		Password: "password",
+		Host:     "localhost",
+		Port:     "2000",
+		Options:  "sslmode=disable",
 	}
-	return nil
-}
-
-func buildUpRealCase() error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		realMigrationPath,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
 }
 
 func TestNewQueryWriter_Generic(t *testing.T) {
-	drop()
-	err := buildUpCase("case9") // case with cycle
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = parameters.NewQueryWriter(db, "some_table")
+	migrator = golangmigrator.New(migrationDir + "case9")
+	db = pgtestdb.New(t, pgConf, migrator)
+	_, err := parameters.NewQueryWriter(db, "some_table")
 	if err == nil {
-		t.Fatal("table doesn't exist in schema, error should have occured")
+		t.Fatal("table doesn't exist in schema, error should have occurred")
 	}
 	_, err = parameters.NewQueryWriter(db, "b")
 	if err == nil {
@@ -62,11 +37,8 @@ func TestNewQueryWriter_Generic(t *testing.T) {
 }
 
 func TestQueryWriter_GenerateEntries(t *testing.T) {
-	drop()
-	err := buildUp()
-	if err != nil {
-		t.Fatal(err)
-	}
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
 	amount := 500
 	writer, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
@@ -83,11 +55,8 @@ func TestQueryWriter_GenerateEntries(t *testing.T) {
 }
 
 func BenchmarkGenerateQueries(b *testing.B) {
-	drop()
-	err := buildUpRealCase()
-	if err != nil {
-		b.Fatal(err)
-	}
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(b, pgConf, migrator)
 	writer, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
 		b.Fatal(err)

--- a/template/insert_template_test.go
+++ b/template/insert_template_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/template"
 	"github.com/Keith1039/dbvg/utils"
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/lib/pq"
+	"github.com/peterldowns/pgtestdb"
+	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
 	"log"
 	"os"
 	"testing"
@@ -26,65 +26,33 @@ var tableData map[string]map[string]string
 
 var requiredTables []string
 
-const path = "file://../db/migrations/"
+const path = "../db/migrations/templates"
 
-func drop() {
-	// drop the database
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	if err != nil {
-		log.Fatal(err)
-	}
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path+"case1",
-		"postgres", driver)
-	if m != nil {
-		err = m.Drop()
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		log.Fatal(err2)
+var pgConf pgtestdb.Config
+
+var migrator pgtestdb.Migrator
+
+func init() {
+	pgConf = pgtestdb.Config{
+		DriverName: "postgres", // uses the lib/pq driver
+		//Database:   "postgres",
+		User:     "postgres",
+		Password: "password",
+		Host:     "localhost",
+		Port:     "2000",
+		Options:  "sslmode=disable",
 	}
 }
 
-func init() {
-	var err error
-	err = os.Setenv("DATABASE_URL", "postgres://postgres:localDB12@localhost:5432/testgres?sslmode=disable")
-	if err != nil {
-		log.Fatal(err)
-	}
-	db, err = sql.Open("postgres", os.Getenv("DATABASE_URL"))
-	if err != nil {
-		panic(err)
-	}
-	drop() // drop the database
-	err = buildUp("templates")
-	if err != nil {
-		log.Fatal(err)
-	}
+func initForTest(t *testing.T) {
+	migrator = golangmigrator.New(path)
+	db = pgtestdb.New(t, pgConf, migrator)
 	tableData = database.GetAllColumnData(db) // set table data
 	ord, err := graph.NewOrdering(db)
 	if err != nil {
 		log.Fatal(err)
 	}
 	requiredTables, err = ord.GetOrder("template")
-}
-
-func buildUp(caseName string) error {
-	// migrate the schema up
-	driver, err := postgres.WithInstance(db, &postgres.Config{})
-	m, err2 := migrate.NewWithDatabaseInstance(
-		path+caseName,
-		"postgres", driver)
-	if m != nil {
-		err = m.Up()
-		if err != nil {
-			return err
-		}
-	} else {
-		return err2
-	}
-	return nil
 }
 
 // to get the desired behavior, we need to take the sample template, shove it into a temporary file
@@ -103,6 +71,7 @@ func writeMapToJSONFile(filePath string, data map[string]map[string]map[string]a
 // this code is to check if certain cases produce the correct errors (missing table etc)
 // this also indirectly tests if the keys are case-insensitive
 func TestGenericErrors(t *testing.T) {
+	initForTest(t)
 	// check for missing table error
 	sampleTemplate = map[string]map[string]map[string]any{
 		"table": {
@@ -172,6 +141,7 @@ func TestGenericErrors(t *testing.T) {
 }
 
 func TestTemplateWithRequiredTables(t *testing.T) {
+	initForTest(t)
 	sampleTemplate = map[string]map[string]map[string]any{
 		"template": {
 			"int": {
@@ -225,6 +195,7 @@ func TestTemplateWithRequiredTables(t *testing.T) {
 // this also applies to the NULL code which is a special code that behaves like an override for any column type
 // the usual checks should still run
 func TestOverrideCode(t *testing.T) {
+	initForTest(t)
 	// sample template with an override code
 	tempDir := t.TempDir()
 	tempFile, err := os.CreateTemp(tempDir, "") // create a temporary file
@@ -266,6 +237,7 @@ func TestOverrideCode(t *testing.T) {
 }
 
 func TestOptionalCodes(t *testing.T) {
+	initForTest(t)
 	var unsupportedErr strategy.UnexpectedTypeError
 	tempDir := t.TempDir()
 	tempFile, err := os.CreateTemp(tempDir, "")
@@ -334,6 +306,7 @@ func TestOptionalCodes(t *testing.T) {
 }
 
 func TestInsertTemplate_GetStrategy(t *testing.T) {
+	initForTest(t)
 	var tmpl *template.InsertTemplate
 	tempDir := t.TempDir()
 	tempFile, err := os.CreateTemp(tempDir, "")
@@ -383,6 +356,7 @@ func TestInsertTemplate_GetStrategy(t *testing.T) {
 }
 
 func TestInsertTemplateDefaults(t *testing.T) {
+	initForTest(t)
 	tempDir := t.TempDir()
 	tempFile, err := os.CreateTemp(tempDir, "")
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -255,7 +255,7 @@ func updateTemplate(oldTemplate map[string]map[string]map[string]any, newTemplat
 		for columnName := range columns {
 			_, ok := oldTemplate[tableName][columnName]
 			if ok {
-				// the system given type is always correct, overwrite the users
+				// assume that new template is given via MakeTemplates() and thus should have the correct type
 
 				if val, ok = oldTemplate[tableName][columnName]["code"]; ok {
 					newTemplate[tableName][columnName]["code"] = val

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -190,4 +190,17 @@ func TestUpdateInsertTemplate(t *testing.T) {
 	if !reflect.DeepEqual(retrievedTemplate, sampleClone) {
 		t.Fatalf("retrieved template '%v'\ninputed template '%v'", retrievedTemplate, sampleClone)
 	}
+	// check if the new type is saved over the old
+	sampleClone["table"]["column"]["TYPE"] = "FLOAT"
+	err = utils.UpdateInsertTemplate(f.Name(), sampleClone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retrievedTemplate, err = utils.RetrieveInsertTemplateJSON(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(retrievedTemplate, sampleClone) {
+		t.Fatalf("retrieved template '%v'\ninputed template '%v'", retrievedTemplate, sampleClone)
+	}
 }


### PR DESCRIPTION
This series of changes is for adding a `docker-compose.yaml` file as well as a dedicated library for database testing. The old method of using a local host postgres db was convenient but ultimately means that future developers would need to have the exact same set up as me. Also, since most tests include destructive behavior like dropping the schema, it allows for a lot to go wrong. Also, some tests would occasionally flake and need to be rerun multiple times before it worked.

Through `docker`, we can set up a standard postgres db on port 2000 with the same user name and password. We can also then introduce a dedicated db testing library called `pgtestdb`. This library is already compatible with `golang migrate` meaning I can simplify much of the existing code. Although there is some slight inefficiencies caused by this approach, it's healthier for the project.

## Other changes:
- Documentation update
- New tests added for both `batch_test.go` and `utils_test.go`