### PR TITLE
Task 29.1: Add Go test workflow for PR and master

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,30 @@
+name: Go
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Start Containers
+        run: docker compose up -d --build
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+
+      - name: Install dependencies
+        run: go get .
+      - name: Test with the Go CLI
+        run: go test -v ./...
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
This commit adds a new workflow that runs automated tests on pushes to `master` and on `PRs`