### PR TITLE
Task 31: Fixing random time strategy & cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,10 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/golang-module/carbon v1.7.3
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.7.1
 	github.com/jimsmart/schema v0.2.1
 	github.com/lib/pq v1.10.9
+	github.com/peterldowns/pgtestdb v0.1.1
+	github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1
 	github.com/spf13/cobra v1.8.1
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8
@@ -20,25 +21,16 @@ require (
 	github.com/gobuffalo/envy v1.7.0 // indirect
 	github.com/gobuffalo/packd v0.3.0 // indirect
 	github.com/gobuffalo/packr v1.30.1 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
-	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/joho/godotenv v1.3.0 // indirect
-	github.com/peterldowns/pgtestdb v0.1.1 // indirect
-	github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/smartystreets/goconvey v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
-	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
-	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/text v0.18.0 // indirect
 )
 
 replace github.com/golang-module/carbon v1.7.3 => github.com/dromara/carbon v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/peterldowns/pgtestdb v0.1.1 h1:+hBCD1DcbKeg5Sfg0G+5WNIy/Cm0ORgwMkF4yg
 github.com/peterldowns/pgtestdb v0.1.1/go.mod h1:yVWInWV0dxvmLdL2ao3nXDzWZ9+G6EhJ4gRwvI1Ozeg=
 github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1 h1:Pe/BsN5eAW+vEpKY0sRW+KqCqG3hXL/MLUfPE2rA4Ak=
 github.com/peterldowns/pgtestdb/migrators/golangmigrator v0.1.1/go.mod h1:q7UGHmppllfXsin8GgnOalCEe9VZgXjzQzOjITupN8E=
+github.com/peterldowns/testy v0.0.1 h1:9a6LzvnKcL52Crzud1z7jbsAojTntCh89ho6mgsr4KU=
+github.com/peterldowns/testy v0.0.1/go.mod h1:J4sm75UEzbfBIcq0zbrshWWjsJQiJ5RrhTPYKVY2Ww8=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/strategy/errors.go
+++ b/strategy/errors.go
@@ -68,7 +68,3 @@ type NotInRangeError struct {
 func (e NotInRangeError) Error() string {
 	return fmt.Sprintf("value '%v' is not within the accepted range: '%s'", e.value, e.rangeStr)
 }
-
-func wrapError(columnType string, code string, err error) error {
-	return fmt.Errorf("for column type '%s' and code '%s': [%w]", columnType, code, err)
-}

--- a/strategy/globals_test.go
+++ b/strategy/globals_test.go
@@ -14,7 +14,7 @@ type factories interface {
 func attemptDeletionForMap[T factories](m map[string]map[string]T) error {
 	var err error
 	for columnType, values := range m {
-		for code, _ := range values {
+		for code := range values {
 			err = strategy.DeleteStrategy(columnType, code)
 			if err == nil {
 				return errors.New(fmt.Sprintf("sucessfully deleted a default, columnType: '%s', code: '%s'", columnType, code))
@@ -23,6 +23,7 @@ func attemptDeletionForMap[T factories](m map[string]map[string]T) error {
 	}
 	return nil
 }
+
 func TestDeleteStrategy(t *testing.T) {
 	// test to see if defaults are up to date
 	override := strategy.GetOverrideCodeMap()
@@ -82,6 +83,7 @@ func testWorkingStrategy() strategy.Strategy {
 func testInvalidStrategy() strategy.Strategy {
 	return &strategy.OptionalStrategy{}
 }
+
 func TestAddOverrideStrategy(t *testing.T) {
 	err := strategy.AddNewOverrideStrategy("something", "new", nil)
 	if err == nil {
@@ -124,6 +126,7 @@ func TestAddOverrideStrategy(t *testing.T) {
 func workingValueStrategy() strategy.ValueStrategy {
 	return &strategy.OptionalStrategy{}
 }
+
 func TestAddNewOptionalStrategy(t *testing.T) {
 	err := strategy.AddNewOptionalStrategy("something", "new", nil)
 	if err == nil {
@@ -163,6 +166,7 @@ func TestAddNewOptionalStrategy(t *testing.T) {
 func workingRequiredValueStrategy() strategy.ValueStrategy {
 	return &strategy.RequiredStrategy{}
 }
+
 func TestAddNewRequiredStrategy(t *testing.T) {
 	err := strategy.AddNewRequiredStrategy("something", "new", nil)
 	if err == nil {

--- a/strategy/optional_test.go
+++ b/strategy/optional_test.go
@@ -5,8 +5,25 @@ import (
 	"fmt"
 	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/utils"
+	"log"
 	"testing"
 )
+
+func init() {
+	// make sure a test runner exists for each Strategy
+	opt := strategy.GetOptionalCodeMap()
+	for typeString, v := range opt {
+		for code := range v {
+			if _, ok := optionalRunnerMap[typeString][code]; !ok {
+				log.Fatalf("missing tests for optional strategy: code '%s' of type '%s'", code, typeString)
+			}
+		}
+	}
+}
+
+var optionalRunnerMap = map[string]map[string]*testRunner{
+	"INT": {"SERIAL": intSerialTestRunner()},
+}
 
 func wrapError(columnType string, code string, err error) error {
 	return fmt.Errorf("for column type '%s' and code '%s': [%w]", columnType, code, err)
@@ -25,19 +42,15 @@ func intSerialTestRunner() *testRunner {
 		}
 		s, ok := t.strategy.(*strategy.OptionalStrategy)
 		if !ok {
-			return errors.New("strategy received could not be cast to `SerialOptionStrategy`")
+			return errors.New("strategy received could not be cast to `OptionalStrategy`")
 		}
 		if val == 20 && s.Value == 21 {
 			return nil
 		} else {
-			return errors.New("expected execution value to be 20 and internal 'Value' paramater to be 21")
+			return errors.New("expected execution value to be 20 and internal 'Value' parameter to be 21")
 		}
 	}
 	return &t
-}
-
-var optionalRunnerMap = map[string]map[string]*testRunner{
-	"INT": {"SERIAL": intSerialTestRunner()},
 }
 
 type testRunner struct {

--- a/strategy/override_test.go
+++ b/strategy/override_test.go
@@ -1,14 +1,26 @@
-package strategy
+package strategy_test
 
 import (
 	"fmt"
+	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/utils"
+	"log"
 	"testing"
 )
 
-func implementsValueStrategy(s Strategy) bool {
-	_, ok := s.(ValueStrategy)
+func implementsValueStrategy(s strategy.Strategy) bool {
+	_, ok := s.(strategy.ValueStrategy)
 	return ok
+}
+
+func init() {
+	// make sure a test runner exists for each Strategy
+	override := strategy.GetOverrideCodeMap()
+	for typeStr := range override {
+		if _, ok := overrideExpectMap[typeStr]; !ok {
+			log.Fatalf("expected type for override strategy of type '%s' missing", typeStr)
+		}
+	}
 }
 
 var overrideExpectMap = map[string]string{
@@ -21,11 +33,12 @@ var overrideExpectMap = map[string]string{
 
 func TestOverrideStrategy_Implements(t *testing.T) {
 	// sample template with an override code
-	for types, codeMap := range overrideCodeMap {
+
+	for types, codeMap := range strategy.GetOverrideCodeMap() {
 		for code, creator := range codeMap {
 			s := creator()
-			if _, ok := s.(ValueStrategy); ok {
-				t.Fatalf("for colummn type '%s' and code '%s': %v", types, code, ValueStrategyImplementedError{})
+			if _, ok := s.(strategy.ValueStrategy); ok {
+				t.Fatalf("for colummn type '%s' and code '%s': %v", types, code, strategy.ValueStrategyImplementedError{})
 			}
 		}
 	}
@@ -33,12 +46,12 @@ func TestOverrideStrategy_Implements(t *testing.T) {
 
 // ensure that null is treated as override
 func TestOverrideStrategy_Null(t *testing.T) {
-	genericNullStrategy, err := GetStrategy("int", "null")
+	genericNullStrategy, err := strategy.GetStrategy("int", "null")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if implementsValueStrategy(genericNullStrategy) {
-		t.Fatal(ValueStrategyImplementedError{})
+		t.Fatal(strategy.ValueStrategyImplementedError{})
 	}
 	res, err := genericNullStrategy.ExecuteStrategy()
 	if err != nil {
@@ -46,12 +59,12 @@ func TestOverrideStrategy_Null(t *testing.T) {
 	}
 
 	if res != nil {
-		t.Fatal(UnexpectedTypeError{ExpectedType: "nil", ActualType: fmt.Sprintf("%T", res)})
+		t.Fatal(strategy.UnexpectedTypeError{ExpectedType: "nil", ActualType: fmt.Sprintf("%T", res)})
 	}
 }
 
 func TestOverrideStrategyReturns(t *testing.T) {
-	for colType, vals := range overrideCodeMap {
+	for colType, vals := range strategy.GetOverrideCodeMap() {
 		for code, creator := range vals {
 			s := creator()
 			val, err := s.ExecuteStrategy()
@@ -59,7 +72,7 @@ func TestOverrideStrategyReturns(t *testing.T) {
 				t.Fatal(err)
 			}
 			if utils.GetStringType(val) != overrideExpectMap[colType] {
-				err = UnexpectedTypeError{ExpectedType: overrideExpectMap[colType], ActualType: utils.GetStringType(val)}
+				err = strategy.UnexpectedTypeError{ExpectedType: overrideExpectMap[colType], ActualType: utils.GetStringType(val)}
 				t.Fatalf("for type '%s' and code '%s': %v", colType, code, err)
 			}
 		}

--- a/strategy/required.go
+++ b/strategy/required.go
@@ -297,11 +297,15 @@ func randomTimeCriteria(val any) error {
 }
 
 func randomTimeStrategy(val any) (any, error) {
-	t1, err := time.Parse(time.TimeOnly, "12:00:00")
+	arr, ok := val.([]string)
+	if !ok {
+		return nil, UnexpectedTypeError{ExpectedType: "[]string", ActualType: utils.GetStringType(val)}
+	}
+	t1, err := time.Parse(time.TimeOnly, arr[0])
 	if err != nil {
 		return nil, err
 	}
-	t2, err := time.Parse(time.TimeOnly, "23:00:00")
+	t2, err := time.Parse(time.TimeOnly, arr[1])
 	if err != nil {
 		return nil, err
 	}

--- a/strategy/required_test.go
+++ b/strategy/required_test.go
@@ -6,10 +6,49 @@ import (
 	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/utils"
 	"github.com/golang-module/carbon"
+	"log"
 	"regexp"
 	"testing"
 	"time"
 )
+
+func init() {
+	// make sure a test runner exists for each Strategy
+	req := strategy.GetRequiredCodeMap()
+	for typeString, v := range req {
+		for code := range v {
+			if _, ok := requiredRunnerMap[typeString][code]; !ok {
+				log.Fatalf("missing tests for required strategy: code '%s' of type '%s'", code, typeString)
+			}
+		}
+	}
+}
+
+var requiredRunnerMap = map[string]map[string]*testRunner{
+	"BOOL": {
+		"STATIC": boolStaticTestRunner(),
+	},
+	"DATE": {
+		"RANDOM": dateRandomTestRunner(),
+		"STATIC": dateStaticTestRunner(),
+	},
+	"TIME": {
+		"RANDOM": timeRandomTestRunner(),
+		"STATIC": timeStaticTestRunner(),
+	},
+	"INT": {
+		"RANDOM": intRandomTestRunner(),
+		"STATIC": intStaticTestRunner(),
+	},
+	"FLOAT": {
+		"RANDOM": floatRandomTestRunner(),
+		"STATIC": floatStaticTestRunner(),
+	},
+	"VARCHAR": {
+		"STATIC": varcharStaticTestRunner(),
+		"REGEX":  varcharRegexTestRunner(),
+	},
+}
 
 type expectedValueError struct {
 	expectedValue any
@@ -55,15 +94,24 @@ func dateRandomTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		arr := s.Value.([]string)
-		t1, _ := utils.GetTimeFromString(arr[0])
-		t2, _ := utils.GetTimeFromString(arr[1])
+		arr, ok := s.Value.([]string)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "[]string", ActualType: utils.GetStringType(s.Value)}
+		}
+		t1, err := utils.GetTimeFromString(arr[0])
+		if err != nil {
+			return err
+		}
+		t2, err := utils.GetTimeFromString(arr[1])
+		if err != nil {
+			return err
+		}
 		t3, ok := val.(time.Time)
 		if !ok {
 			return strategy.UnexpectedTypeError{ExpectedType: "time.Time", ActualType: utils.GetStringType(val)}
 		}
 		if t3.Before(t1) || t3.After(t2) {
-			return errors.New(fmt.Sprintf("generated value '%v' is out of bounds of value '%v", t3, arr))
+			return strategy.RandomBoundError{LowerBound: t1, UpperBound: t2}
 		}
 		return nil
 	}
@@ -75,15 +123,17 @@ func dateStaticTestRunner() *testRunner {
 		testValues:     []any{false, "01-02-2026", carbon.Parse("2026-03-01").ToRfc3339String()},
 		expectedErrors: []error{strategy.UnexpectedTypeError{}, strategy.ImproperDateStringFormatError{}},
 	}
-
 	t.evalCriteria = func(val any) error {
 		s, ok := t.strategy.(*strategy.RequiredStrategy)
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		return staticEvaluator(val, carbon.Parse(s.Value.(string)).ToStdTime())
+		date, ok := s.Value.(string)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "string", ActualType: utils.GetStringType(s.Value)}
+		}
+		return staticEvaluator(val, carbon.Parse(date).ToStdTime())
 	}
-
 	return &t
 }
 
@@ -98,7 +148,15 @@ func timeStaticTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		return staticEvaluator(val, carbon.Parse(s.Value.(string)).ToStdTime())
+		timeStr, ok := s.Value.(string)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "string", ActualType: utils.GetStringType(s.Value)}
+		}
+		timeObj, err := time.Parse(time.TimeOnly, timeStr)
+		if err != nil {
+			return err
+		}
+		return staticEvaluator(val, timeObj)
 	}
 
 	return &t
@@ -108,7 +166,7 @@ func timeRandomTestRunner() *testRunner {
 	t := testRunner{
 		testValues: []any{"", []string{"", "", ""}, []string{"03-01-2025", "2025-01-02"},
 			[]string{"00:00:00", "24:00:00"}, []string{"13:00:00", "00:00:00"},
-			[]string{"00:00:00", "23:00:00"}},
+			[]string{"00:00:00", "02:00:00"}},
 		expectedErrors: []error{strategy.UnexpectedTypeError{}, strategy.UnexpectedArrayLengthError{}, strategy.ImproperTimeStringFormatError{},
 			strategy.ImproperTimeStringFormatError{}, strategy.RandomBoundError{}},
 	}
@@ -117,15 +175,24 @@ func timeRandomTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		arr := s.Value.([]string)
-		t1, _ := utils.GetTimeFromString(arr[0])
-		t2, _ := utils.GetTimeFromString(arr[1])
+		arr, ok := s.Value.([]string)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "[]string", ActualType: utils.GetStringType(s.Value)}
+		}
+		t1, err := time.Parse(time.TimeOnly, arr[0])
+		if err != nil {
+			return err
+		}
+		t2, err := time.Parse(time.TimeOnly, arr[1])
+		if err != nil {
+			return err
+		}
 		t3, ok := val.(time.Time)
 		if !ok {
 			return strategy.UnexpectedTypeError{ExpectedType: "time.Time", ActualType: utils.GetStringType(val)}
 		}
 		if t3.Before(t1) || t3.After(t2) {
-			return errors.New(fmt.Sprintf("generated value '%v' is out of bounds of value '%v", t3, arr))
+			return strategy.RandomBoundError{LowerBound: t1, UpperBound: t2}
 		}
 		return nil
 	}
@@ -142,14 +209,18 @@ func intRandomTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		lowerBound := s.Value.([]int)[0]
-		upperBound := s.Value.([]int)[1]
+		arr, ok := s.Value.([]int)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "[]int", ActualType: utils.GetStringType(s.Value)}
+		}
+		lowerBound := arr[0]
+		upperBound := arr[1]
 		intVal, ok := val.(int)
 		if !ok {
-			return errors.New("not int")
+			return strategy.UnexpectedTypeError{ExpectedType: "int", ActualType: utils.GetStringType(val)}
 		}
 		if intVal < lowerBound || intVal > upperBound {
-			return errors.New(fmt.Sprintf("generated value '%v' is out of bounds of value '%v", val, s.Value))
+			return strategy.RandomBoundError{LowerBound: lowerBound, UpperBound: upperBound}
 		}
 		return nil
 	}
@@ -183,14 +254,18 @@ func floatRandomTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		lowerBound := s.Value.([]float64)[0]
-		upperBound := s.Value.([]float64)[1]
+		arr, ok := s.Value.([]float64)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "[]float64", ActualType: utils.GetStringType(s.Value)}
+		}
+		lowerBound := arr[0]
+		upperBound := arr[1]
 		floatVal, ok := val.(float64)
 		if !ok {
-			return errors.New("not float")
+			return strategy.UnexpectedTypeError{ExpectedType: "float64", ActualType: utils.GetStringType(val)}
 		}
 		if floatVal < lowerBound || floatVal > upperBound {
-			return errors.New(fmt.Sprintf("generated value '%v' is out of bounds of value '%v", val, s.Value))
+			return strategy.RandomBoundError{LowerBound: lowerBound, UpperBound: upperBound}
 		}
 		return nil
 	}
@@ -240,8 +315,14 @@ func varcharRegexTestRunner() *testRunner {
 		if !ok {
 			return errors.New("strategy could not be cast to 'RequiredStrategy'")
 		}
-		regex := s.Value.(string)
-		regexStr := val.(string)
+		regex, ok := s.Value.(string)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "string", ActualType: utils.GetStringType(s.Value)}
+		}
+		regexStr, ok := val.(string)
+		if !ok {
+			return strategy.UnexpectedTypeError{ExpectedType: "string", ActualType: utils.GetStringType(val)}
+		}
 		matched, err := regexp.MatchString(regex, regexStr)
 		if err != nil {
 			return err
@@ -252,28 +333,6 @@ func varcharRegexTestRunner() *testRunner {
 		return nil
 	}
 	return &t
-}
-
-var requiredRunnerMap = map[string]map[string]*testRunner{
-	"BOOL": {
-		"STATIC": boolStaticTestRunner(),
-	},
-	"DATE": {
-		"RANDOM": dateRandomTestRunner(),
-		"STATIC": dateStaticTestRunner(),
-	},
-	"INT": {
-		"RANDOM": intRandomTestRunner(),
-		"STATIC": intStaticTestRunner(),
-	},
-	"FLOAT": {
-		"RANDOM": floatRandomTestRunner(),
-		"STATIC": floatStaticTestRunner(),
-	},
-	"VARCHAR": {
-		"STATIC": varcharStaticTestRunner(),
-		"REGEX":  varcharRegexTestRunner(),
-	},
 }
 
 func TestRequiredStrategies(t *testing.T) {

--- a/template/code_error.go
+++ b/template/code_error.go
@@ -2,29 +2,7 @@ package template
 
 import (
 	"fmt"
-	"strings"
 )
-
-// unsupportedCodeError is an error given when the code given by the template isn't supported by it's type
-type unsupportedCodeError struct {
-	code       string
-	columnType string
-}
-
-func (e unsupportedCodeError) Error() string {
-	return fmt.Sprintf("code '%s' is not supported for the type '%s'", e.code, e.columnType)
-}
-
-// unsupportedTypeError  is an error given when the value given by the template doesn't match a supported type for that code
-type unsupportedTypeError struct {
-	typeStr        string
-	code           string
-	supportedTypes []string
-}
-
-func (e unsupportedTypeError) Error() string {
-	return fmt.Sprintf("type '%s' is not supported for the code '%s'. Types supported are [%s]", e.typeStr, e.code, strings.Join(e.supportedTypes, ","))
-}
 
 // RandomBoundError is an error given when the lower bound of a "RANDOM" code is greater than the upper bound
 type RandomBoundError struct {
@@ -44,10 +22,6 @@ type UnexpectedArrayLengthError struct {
 
 func (e UnexpectedArrayLengthError) Error() string {
 	return fmt.Sprintf("expected array of length %d, received an array of length %d", e.expectedLength, e.actualLength)
-}
-
-func NewUnexpectedArrayLengthError(expectedLength int, actualLength int) UnexpectedArrayLengthError {
-	return UnexpectedArrayLengthError{expectedLength, actualLength}
 }
 
 // InvalidRegexError is an error given when the regex string, when given to `regexp.compile()`, returns an error

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -36,11 +36,6 @@ func ListToStringArray(l *list.List) []string {
 	return listToArray[string](l)
 }
 
-// ListToAnyArray takes in a linked list and returns it as an any array
-func ListToAnyArray(l *list.List) []any {
-	return listToArray[any](l)
-}
-
 // MakeTemplates takes in a database connection and an array of tables and formats it into a map suitable for JSON
 func MakeTemplates(db *sql.DB, tableOrder []string) map[string]map[string]map[string]any {
 	m := make(map[string]map[string]map[string]any)


### PR DESCRIPTION
This PR focuses on fixing the `RANDOM` code for the `TIME` type. It also introduces `init` functions for strategy testing to ensure that tests fail if a defined strategy does not have a test associated with it. This was due to `TIME` `RANDOM` having a test runner but wasn't added to the map in order to be ran. This should fix this.

## Other Changes:
- Improved error handling
- Strategy tests now used defined errors (for the most part)
- Changed a test to use the `strategy_test` package instead of `strategy`
- Deleting unused code
- Updated go mod & go sum
- Upgraded go mod & go sum