### PR TITLE
Task 32: Adding more transparency to CLI

### DIFF
--- a/cmd/format/insert_template.go
+++ b/cmd/format/insert_template.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Keith1039/dbvg/utils"
 	"github.com/spf13/cobra"
 	"log"
+	"strings"
 )
 
 var table string
@@ -49,9 +50,15 @@ ex)
 		}
 		templates := utils.MakeTemplates(db, tableOrder)
 		if update {
-			err = utils.UpdateInsertTemplate(path, templates)
+			changes, err := utils.UpdateInsertTemplate(path, templates)
 			if err != nil {
 				log.Fatal(err)
+			}
+			if len(changes) > 0 {
+				fmt.Println(fmt.Sprintf("the followng changes were applied to the template at path '%s':", path))
+				fmt.Println(strings.Join(changes, "\n"))
+			} else {
+				fmt.Println(fmt.Sprintf("no changes made to the template at path '%s'", path))
 			}
 		} else if verify {
 			_, err = template.NewInsertTemplate(database.GetAllColumnData(db), tableOrder, path)
@@ -61,10 +68,12 @@ ex)
 				fmt.Println(fmt.Sprintf("template at '%s' contains no errors", path))
 			}
 		} else {
+			// create code
 			err = utils.WriteInsertTemplateToFile(path, templates)
 			if err != nil {
 				log.Fatal(err)
 			}
+			fmt.Println(fmt.Sprintf("template successfully created at '%s'", path))
 		}
 	},
 }
@@ -74,7 +83,6 @@ func init() {
 	insertTemplateCmd.Flags().BoolVarP(&update, "update", "u", false, "update the given template with current schema information")
 	insertTemplateCmd.Flags().BoolVarP(&verify, "verify", "", false, "run deep verification on the template by checking codes and values")
 	insertTemplateCmd.Flags().BoolVarP(&create, "create", "c", false, "create a new template")
-
 	insertTemplateCmd.MarkFlagsOneRequired("create", "update", "verify")
 	err := insertTemplateCmd.MarkFlagRequired("table")
 	if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -180,12 +180,14 @@ func WriteInsertTemplateToFile(path string, data map[string]map[string]map[strin
 // This includes adding new tables, removing irrelevant tables and altering types.
 // Shallow verification is done on the given template to ensure that each is valid
 // before overwriting data.
+//
 // Code and value pairs from the old template are still moved into the new template if there
-// is a matching entry
-func UpdateInsertTemplate(path string, newTemplate map[string]map[string]map[string]any) error {
+// is a matching entry. This function returns an array of changes made i.e. tables/columns that were added or removed
+// alongside any errors.
+func UpdateInsertTemplate(path string, newTemplate map[string]map[string]map[string]any) ([]string, error) {
 	data, err := RetrieveInsertTemplateJSON(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// we normalize for existing template to see if there's useful data
 	for _, columnInfo := range data {
@@ -196,14 +198,14 @@ func UpdateInsertTemplate(path string, newTemplate map[string]map[string]map[str
 	// for the normalization as well
 	err = verifyTemplate(newTemplate)
 	if err != nil {
-		return fmt.Errorf("for the template at '%s' the following error occured: [%w]", path, err)
+		return nil, fmt.Errorf("for the template at '%s' the following error occured: [%w]", path, err)
 	}
-	updateTemplate(data, newTemplate)
+	changes := updateTemplate(data, newTemplate)
 	err = WriteInsertTemplateToFile(path, newTemplate)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return changes, nil
 }
 
 func normalizeKeys(columnInfo map[string]any) {
@@ -244,23 +246,45 @@ func verifyTemplate(m map[string]map[string]map[string]any) error {
 	return nil
 }
 
-func updateTemplate(oldTemplate map[string]map[string]map[string]any, newTemplate map[string]map[string]map[string]any) {
+func updateTemplate(oldTemplate map[string]map[string]map[string]any, newTemplate map[string]map[string]map[string]any) []string {
 	var val any
+	var changesArr []string
+	// adding to the new template and getting all the new additions
 	for tableName, columns := range newTemplate {
-		for columnName := range columns {
-			_, ok := oldTemplate[tableName][columnName]
-			if ok {
-				// assume that new template is given via MakeTemplates() and thus should have the correct type
+		_, ok := oldTemplate[tableName]
+		if !ok {
+			changesArr = append(changesArr, fmt.Sprintf("+ new table '%s' added", tableName))
+		} else {
+			for columnName := range columns {
+				_, ok = oldTemplate[tableName][columnName]
+				if ok {
+					// assume that new template is given via MakeTemplates() and thus should have the correct type
 
-				if val, ok = oldTemplate[tableName][columnName]["code"]; ok {
-					newTemplate[tableName][columnName]["code"] = val
-				}
-				if val, ok = oldTemplate[tableName][columnName]["value"]; ok {
-					newTemplate[tableName][columnName]["value"] = val
+					if val, ok = oldTemplate[tableName][columnName]["code"]; ok {
+						newTemplate[tableName][columnName]["code"] = val
+					}
+					if val, ok = oldTemplate[tableName][columnName]["value"]; ok {
+						newTemplate[tableName][columnName]["value"] = val
+					}
+				} else {
+					changesArr = append(changesArr, fmt.Sprintf("+ new column '%s' added to table '%s'", columnName, tableName))
 				}
 			}
 		}
 	}
+	// now to get the deletions
+	for tableName, columns := range oldTemplate {
+		if _, ok := newTemplate[tableName]; !ok {
+			changesArr = append(changesArr, fmt.Sprintf("- table '%s' removed", tableName))
+		} else {
+			for columnName := range columns {
+				if _, ok = newTemplate[tableName][columnName]; !ok {
+					changesArr = append(changesArr, fmt.Sprintf("- column '%s' removed from table '%s'", columnName, tableName))
+				}
+			}
+		}
+	}
+	return changesArr
 }
 
 // GetStringType is a function take takes in a value of any type and returns the string name of the type of value given

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -150,12 +150,12 @@ func TestUpdateInsertTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = utils.UpdateInsertTemplate(f.Name(), sampleTemplate)
+	_, err = utils.UpdateInsertTemplate(f.Name(), sampleTemplate)
 	if err == nil {
 		t.Fatal("value key missing, error should have occurred")
 	}
 	sampleTemplate["table"]["column"]["vaLue"] = any(5)
-	err = utils.UpdateInsertTemplate(f.Name(), sampleTemplate)
+	_, err = utils.UpdateInsertTemplate(f.Name(), sampleTemplate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestUpdateInsertTemplate(t *testing.T) {
 			"value": any("XD"),
 		},
 	}
-	err = utils.UpdateInsertTemplate(f.Name(), sampleTemplate)
+	_, err = utils.UpdateInsertTemplate(f.Name(), sampleTemplate)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestUpdateInsertTemplate(t *testing.T) {
 		t.Fatalf("retrieved template '%v'\ninputed template '%v'", retrievedTemplate, sampleTemplate)
 	}
 	// check to see if irrelevant data is left out
-	err = utils.UpdateInsertTemplate(f.Name(), sampleClone)
+	_, err = utils.UpdateInsertTemplate(f.Name(), sampleClone)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestUpdateInsertTemplate(t *testing.T) {
 	}
 	// check if the new type is saved over the old
 	sampleClone["table"]["column"]["TYPE"] = "FLOAT"
-	err = utils.UpdateInsertTemplate(f.Name(), sampleClone)
+	_, err = utils.UpdateInsertTemplate(f.Name(), sampleClone)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit is to add more transparency in regards to what the CLI is doing. In this case, it is about being transparent about what the CLI is doing in regards to templates. When updating a template, the CLI needs to be open about how the template was modified. This helps in debugging as well as with the user experience.

This is done by returning a list of changes/operations that were done to the user's template when `UpdateInsertTemplate()` is called alongside any errors.