### PR TITLE
Task 34: Refactor Insert-Template

### DIFF
--- a/cmd/format/insert_template.go
+++ b/cmd/format/insert_template.go
@@ -61,7 +61,7 @@ ex)
 				fmt.Println(fmt.Sprintf("no changes made to the template at path '%s'", path))
 			}
 		} else if verify {
-			_, err = template.NewInsertTemplate(database.GetAllColumnData(db), tableOrder, path)
+			_, err = template.NewInsertTemplate(db, table, path)
 			if err != nil {
 				log.Fatalf("template at '%s' failed with error [%v]", path, err)
 			} else {

--- a/db/migrations/templates/000001_template_testing.up.sql
+++ b/db/migrations/templates/000001_template_testing.up.sql
@@ -1,12 +1,21 @@
 CREATE TABLE IF NOT EXISTS TEMPLATE(
-    uuid UUID,
+    uuid UUID PRIMARY KEY,
     int INT,
     float FLOAT,
     bool BOOLEAN,
     varchar VARCHAR,
-    date DATE
+    date DATE,
+    time TIME
 );
 
-CREATE TABLE IF NOT EXISTS IRRELIVANT(
-    key SERIAL PRIMARY KEY
+CREATE TABLE IF NOT EXISTS IRRELEVANT(
+    key SERIAL PRIMARY KEY,
+    template_key UUID,
+    FOREIGN KEY (template_key) REFERENCES TEMPLATE(uuid)
+);
+
+CREATE TABLE IF NOT EXISTS CYCLETABLE(
+    key SERIAL primary key,
+    key2 SERIAL,
+    FOREIGN KEY (key2) REFERENCES CYCLETABLE(key)
 )

--- a/parameters/query_writer.go
+++ b/parameters/query_writer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Keith1039/dbvg/template"
 	"github.com/Keith1039/dbvg/utils"
 	"log"
-	"os"
 	"strings"
 )
 
@@ -23,7 +22,7 @@ func NewQueryWriter(db *sql.DB, tableName string) (*QueryWriter, error) {
 	if err != nil {
 		return nil, err // return the error
 	}
-	qw.template, err = template.NewDefaultInsertTemplate(db, qw.TableOrder)
+	qw.template, err = template.NewDefaultInsertTemplate(db, qw.tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -35,15 +34,12 @@ func NewQueryWriter(db *sql.DB, tableName string) (*QueryWriter, error) {
 // before returning a pointer to the initialized QueryWriter as well as any errors that occurred
 func NewQueryWriterWithTemplate(db *sql.DB, tableName string, filePath string) (*QueryWriter, error) {
 	// check to see if file exists
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
-		return nil, err
-	}
 	qw := QueryWriter{db: db, tableName: tableName}
 	err := qw.init()
 	if err != nil {
 		return nil, err
 	}
-	qw.template, err = template.NewInsertTemplate(database.GetAllColumnData(db), qw.TableOrder, filePath)
+	qw.template, err = template.NewInsertTemplate(db, qw.tableName, filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/template/default_test.go
+++ b/template/default_test.go
@@ -1,0 +1,81 @@
+package template_test
+
+import (
+	"github.com/Keith1039/dbvg/strategy"
+	"github.com/Keith1039/dbvg/template"
+	"reflect"
+	"testing"
+)
+
+func TestGetDefault(t *testing.T) {
+	defaults := template.GetDefaults()
+	defaults["NEW TYPE"] = func() strategy.Strategy { return &strategy.OverrideStrategy{} }
+	defaults2 := template.GetDefaults()
+	if reflect.DeepEqual(defaults, defaults2) {
+		t.Fatal("changes made to the clone should not affect the internal values")
+	}
+}
+
+// check if executing default strategies can be executed as is
+func TestGetDefaultExec(t *testing.T) {
+	defaults := template.GetDefaults()
+	for typeString, stratFunc := range defaults {
+		strat := stratFunc()
+		_, err := strat.ExecuteStrategy()
+		if err != nil {
+			t.Fatalf("default strategy of type '%s' failed with error '%v'", typeString, err)
+		}
+	}
+}
+
+func TestGetDefaultCodes(t *testing.T) {
+	defaults := template.GetDefaultCodes()
+	defaults["INT"] = "NULL"
+	defaults2 := template.GetDefaultCodes()
+	if reflect.DeepEqual(defaults, defaults2) {
+		t.Fatal("changes made to the clone should not affect the internal values")
+	}
+}
+
+// a strategy is the same if it has the same strategy and criteria function
+//func strategyIsEqual(stratA strategy.Strategy, stratB strategy.Strategy) bool {
+//	override1, ok := stratA.(*strategy.OverrideStrategy)
+//	override2, ok2 := stratB.(*strategy.OverrideStrategy)
+//	if ok && ok2 {
+//		// check if they point to te same strategy
+//		return reflect.DeepEqual(override1, override2)
+//	}
+//
+//	optional1, ok := stratA.(*strategy.OptionalStrategy)
+//	optional2, ok2 := stratB.(*strategy.OptionalStrategy)
+//	if ok && ok2 {
+//		return reflect.DeepEqual(optional1, optional2)
+//	}
+//
+//	required1, ok := stratA.(*strategy.RequiredStrategy)
+//	required2, ok2 := stratB.(*strategy.RequiredStrategy)
+//	if ok && ok2 {
+//		return reflect.DeepEqual(required1, required2)
+//	}
+//	return false
+//}
+
+//func TestCodeAndStrategyAlignment(t *testing.T) {
+//	defaultStrategies := template.GetDefaults()
+//	defaultCodes := template.GetDefaultCodes()
+//	for typeStr, code := range defaultCodes {
+//		stratFunc, ok := defaultStrategies[typeStr]
+//		if !ok {
+//			t.Fatalf("missing strategy for type '%s'", typeStr)
+//		}
+//		strat := stratFunc()
+//		expectedStrat, err := strategy.GetStrategy(typeStr, code)
+//		if err != nil {
+//			t.Fatal(err)
+//		}
+//		if !strategyIsEqual(strat, expectedStrat) {
+//			t.Fatalf("strategy of type '%s' for code '%s' doesn't match expected", typeStr, code)
+//		}
+//
+//	}
+//}

--- a/template/defaults.go
+++ b/template/defaults.go
@@ -1,6 +1,9 @@
 package template
 
-import "github.com/Keith1039/dbvg/strategy"
+import (
+	"github.com/Keith1039/dbvg/strategy"
+	"maps"
+)
 
 var DEFAULTREGEX = "[a-zA-Z]{10}"
 
@@ -14,6 +17,12 @@ var defaults = map[string]func() strategy.Strategy{
 	"VARCHAR": defaultRegex,
 }
 
+// GetDefaults returns a clone of the internal defaults map linking the types to their
+// Strategies. These Strategies can be executed as is
+func GetDefaults() map[string]func() strategy.Strategy {
+	return maps.Clone(defaults)
+}
+
 var defaultCode = map[string]string{
 	"INT":     "SERIAL",
 	"FLOAT":   "RANDOM",
@@ -22,6 +31,12 @@ var defaultCode = map[string]string{
 	"TIME":    "NOW",
 	"BOOL":    "RANDOM",
 	"VARCHAR": "REGEX",
+}
+
+// GetDefaultCodes returns a clone of the internal defaultCode map linking a type
+// to the code represented in the defaults map.
+func GetDefaultCodes() map[string]string {
+	return maps.Clone(defaultCode)
 }
 
 func defaultFloatRandom() strategy.Strategy {

--- a/template/errors.go
+++ b/template/errors.go
@@ -41,6 +41,25 @@ type MissingRequiredTableError struct {
 	jsonKeys  []string
 }
 
+// MissingRequiredTableError is an error given when a template is missing a required table
 func (err MissingRequiredTableError) Error() string {
 	return fmt.Sprintf("missing required table '%s' in template keys [%s]", err.tableName, strings.Join(err.jsonKeys, ", "))
+}
+
+// MissingRequiredColumnError is an error given when a template is missing a required column
+type MissingRequiredColumnError struct {
+	columnName string
+	tableName  string
+}
+
+func (err MissingRequiredColumnError) Error() string {
+	return fmt.Sprintf("missing required column '%s' for table '%s'", err.columnName, err.tableName)
+}
+
+// MissingPathError is an error given when the required parameter 'path' is empty
+type MissingPathError struct {
+}
+
+func (err MissingPathError) Error() string {
+	return fmt.Sprintf("'path' variable cannot be empty")
 }

--- a/template/insert_template.go
+++ b/template/insert_template.go
@@ -17,31 +17,28 @@ var insertSchema = map[string]string{
 	"value": "any",
 }
 
-func makeInsertTemplate(tableData map[string]map[string]string, requiredTables []string, path string) (*InsertTemplate, error) {
+func makeInsertTemplate(db *sql.DB, table string, path string) (*InsertTemplate, error) {
 	t := &InsertTemplate{}
 	t.strategyMap = make(map[string]map[string]StrategyCodePair) // initialize map
-	err := t.templateFrom(tableData, requiredTables, path)
+	err := t.templateFrom(db, table, path)
 	if err != nil {
 		return nil, err
 	}
 	return t, nil
 }
 
-// NewInsertTemplate creates a InsertTemplate struct using a static map, this is to prevent multiple duplicate
-// database queries. Process is identical to NewInsertTemplateWithDB
-func NewInsertTemplate(tableData map[string]map[string]string, requiredTables []string, path string) (*InsertTemplate, error) {
-	return makeInsertTemplate(tableData, requiredTables, path)
+// NewInsertTemplate creates a InsertTemplate for a table from an existing template indicated by
+// the path variable
+func NewInsertTemplate(db *sql.DB, table string, path string) (*InsertTemplate, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, MissingPathError{}
+	}
+	return makeInsertTemplate(db, table, path)
 }
 
-func NewDefaultInsertTemplate(db *sql.DB, requiredTables []string) (*InsertTemplate, error) {
-	defaultTemplateData := utils.MakeTemplates(db, requiredTables)
-	tableData := database.GetAllColumnData(db)
-	t := &InsertTemplate{}
-	err := t.defaultTemplateFrom(tableData, requiredTables, defaultTemplateData)
-	if err != nil {
-		return nil, err
-	}
-	return t, nil
+// NewDefaultInsertTemplate creates a InsertTemplate struct with a standard template
+func NewDefaultInsertTemplate(db *sql.DB, table string) (*InsertTemplate, error) {
+	return makeInsertTemplate(db, table, "")
 }
 
 // StrategyCodePair is a struct only meant to facilitate the transfer of information between packages
@@ -61,22 +58,28 @@ type InsertTemplate struct {
 }
 
 // fills the struct with data
-func (t *InsertTemplate) templateFrom(tableData map[string]map[string]string, requiredTables []string, path string) error {
-	data, err := utils.RetrieveInsertTemplateJSON(path) // run some validation and retrieve JSON data
-	if err != nil {                                     // error check
-		return err
+func (t *InsertTemplate) templateFrom(db *sql.DB, table string, path string) error {
+	var data map[string]map[string]map[string]any
+	var err error
+	var ord *graph.Ordering
+	var order []string
+	if path != "" {
+		data, err = utils.RetrieveInsertTemplateJSON(path) // run some validation and retrieve JSON data
+		if err != nil {                                    // error check
+			return err
+		}
+	} else {
+		ord, err = graph.NewOrdering(db)
+		if err != nil {
+			return err
+		}
+		order, err = ord.GetOrder(table)
+		if err != nil {
+			return err
+		}
+		data = utils.MakeTemplates(db, order)
 	}
-	err = t.validateTemplate(data, tableData, insertSchema, requiredTables) // validate the data given to see if it matches schema
-	// add an extra step for checking if the value has a type that is supported by the code
-	if err != nil { // error check
-		return err
-	}
-	return nil
-}
-
-func (t *InsertTemplate) defaultTemplateFrom(tableData map[string]map[string]string, requiredTables []string, templateData map[string]map[string]map[string]any) error {
-	t.strategyMap = make(map[string]map[string]StrategyCodePair)                     // initialize map
-	err := t.validateTemplate(templateData, tableData, insertSchema, requiredTables) // validate the data given to see if it matches schema
+	err = t.validateTemplate(db, table, data, insertSchema, path == "") // validate the data given to see if it matches schema
 	// add an extra step for checking if the value has a type that is supported by the code
 	if err != nil { // error check
 		return err
@@ -85,41 +88,69 @@ func (t *InsertTemplate) defaultTemplateFrom(tableData map[string]map[string]str
 }
 
 // validateTemplate confirms that the information gained from a JSON file is valid through a series of checks
-func (t *InsertTemplate) validateTemplate(jsonData map[string]map[string]map[string]any, tableData map[string]map[string]string, schema map[string]string, requiredTables []string) error {
+func (t *InsertTemplate) validateTemplate(db *sql.DB, table string, jsonData map[string]map[string]map[string]any, schema map[string]string, validated bool) error {
 	var typeMap map[string]string
-
-	requiredTableMap := make(map[string]bool)
-	// check if names in required tables exist in map and add to map
-	for _, tableName := range requiredTables {
-		if _, ok := tableData[tableName]; !ok {
-			return MissingRequiredTableError{tableName: tableName, jsonKeys: slices.Collect(maps.Keys(tableData))}
-		} else {
-			requiredTableMap[tableName] = true
+	if !validated {
+		tableData := database.GetAllColumnData(db)
+		allRelations := database.GetRelationships(db)
+		ord, err := graph.NewOrdering(db)
+		if err != nil {
+			return err
 		}
-	}
-
-	for tableName, columns := range jsonData { // loop through each key
-		if _, ok := tableData[tableName]; !ok { // check if the tableName exists in the schema
-			return graph.NewMissingTableError(tableName)
+		requiredTables, err := ord.GetOrder(table)
+		if err != nil {
+			return err
 		}
-		// condition to ignore irrelevant tables (i.e. any table that isn't required)
-		if _, ok := requiredTableMap[tableName]; ok {
+		requiredTableMap := make(map[string]bool)
+		requiredColMap := make(map[string]bool)
+		// check if names in required tables exist in template
+		for _, tableName := range requiredTables {
+			if _, ok := jsonData[tableName]; !ok {
+				return MissingRequiredTableError{tableName: tableName, jsonKeys: slices.Collect(maps.Keys(tableData))}
+			} else {
+				// check if we have all the right columns for the table (all non-FK tables)
+				for col := range tableData[tableName] {
+					_, ok = jsonData[tableName][col]
+					_, isFk := allRelations[tableName][col]
+					if !ok && !isFk {
+						return MissingRequiredColumnError{tableName: tableName, columnName: col}
+					} else if ok && !isFk {
+						requiredColMap[col] = true
+					}
+				}
+				requiredTableMap[tableName] = true
+			}
+		}
+
+		for tableName, columns := range jsonData { // loop through each key
+			// condition to ignore irrelevant tables (i.e. any table that isn't required)
+			if _, ok := requiredTableMap[tableName]; ok {
+				for colName, columnInfo := range columns {
+					// ignore irrelevant columns
+					if _, ok = requiredColMap[colName]; ok {
+						normalizeKeys(columnInfo)                 // trims and lowers each key while maintaining the key value pairs
+						typeMap = makeTypeMap(columnInfo)         // check the types for the key value pairs in the template
+						err = checkAgainstSchema(typeMap, schema) // check the type map against the schema
+						if err != nil {
+							return wrapError(tableName, colName, err)
+						}
+						normalizeType(columnInfo) // ensures the convention of the type field
+						err = checkExpectedType(tableData[tableName][colName], columnInfo["type"].(string))
+						if err != nil {
+							return wrapError(tableName, colName, err)
+						}
+						err = t.checkCodesAndSetStrategy(tableName, colName, columnInfo)
+						if err != nil {
+							return wrapError(tableName, colName, err)
+						}
+					}
+				}
+			}
+		}
+	} else {
+		for tableName, columns := range jsonData { // loop through each key
 			for colName, columnInfo := range columns {
-				if _, ok = tableData[tableName][colName]; !ok { // check if the column exists in that schema
-					return graph.NewMissingColumnError(tableName, colName)
-				}
-				normalizeKeys(columnInfo)                  // trims and lowers each key while maintaining the key value pairs
-				typeMap = makeTypeMap(columnInfo)          // check the types for the key value pairs in the template
-				err := checkAgainstSchema(typeMap, schema) // check the type map against the schema
-				if err != nil {
-					return wrapError(tableName, colName, err)
-				}
-				normalizeType(columnInfo) // ensures the convention of the type field
-				err = checkExpectedType(tableData[tableName][colName], columnInfo["type"].(string))
-				if err != nil {
-					return wrapError(tableName, colName, err)
-				}
-				err = t.checkCodesAndSetStrategy(tableName, colName, columnInfo)
+				err := t.checkCodesAndSetStrategy(tableName, colName, columnInfo)
 				if err != nil {
 					return wrapError(tableName, colName, err)
 				}

--- a/template/insert_template_test.go
+++ b/template/insert_template_test.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	database "github.com/Keith1039/dbvg/db"
 	"github.com/Keith1039/dbvg/graph"
 	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/template"
@@ -13,18 +12,16 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/peterldowns/pgtestdb"
 	"github.com/peterldowns/pgtestdb/migrators/golangmigrator"
-	"log"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 var db *sql.DB
 
-var sampleTemplate map[string]map[string]map[string]any
+var testCase map[string]map[string]map[string]any
 
-var tableData map[string]map[string]string
-
-var requiredTables []string
+var table string
 
 const path = "../db/migrations/templates"
 
@@ -42,17 +39,22 @@ func init() {
 		Port:     "2000",
 		Options:  "sslmode=disable",
 	}
+
 }
 
 func initForTest(t *testing.T) {
 	migrator = golangmigrator.New(path)
 	db = pgtestdb.New(t, pgConf, migrator)
-	tableData = database.GetAllColumnData(db) // set table data
+	table = "irrelevant"
 	ord, err := graph.NewOrdering(db)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatal(err)
 	}
-	requiredTables, err = ord.GetOrder("template")
+	tables, err := ord.GetOrder(table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCase = utils.MakeTemplates(db, tables)
 }
 
 // to get the desired behavior, we need to take the sample template, shove it into a temporary file
@@ -68,273 +70,316 @@ func writeMapToJSONFile(filePath string, data map[string]map[string]map[string]a
 	return nil
 }
 
+func getTempDirAndFile(t *testing.T) (*os.File, string) {
+	dir := t.TempDir()
+	f, err := os.CreateTemp(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f, dir
+}
+
+func getTemplate(db *sql.DB, table string) (map[string]map[string]map[string]any, error) {
+	table = utils.TrimAndLowerString(table)
+	ord, err := graph.NewOrdering(db)
+	if err != nil {
+		return nil, err
+	}
+	tables, err := ord.GetOrder(table)
+	if err != nil {
+		return nil, err
+	}
+	templ := utils.MakeTemplates(db, tables)
+	return templ, nil
+}
+
+func writeInvalidTemplateToFile(path string, data map[string]bool) error {
+	// by default this will overwrite existing files
+	cleanPath, err := utils.CleanFilePath(path) // make sure the path is clean
+	if err != nil {
+		return err
+	}
+	dir, fileName := filepath.Split(cleanPath) // split the dir path and the file name
+	if dir != "" {                             // check if the dir path is empty string
+		if _, err = os.Stat(dir); os.IsNotExist(err) { // check if directory exists
+			err = os.MkdirAll(dir, os.ModePerm) // make all directories and subdirectories
+			if err != nil {
+				return err // log error and exit
+			}
+		}
+	}
+	jsonData, err := json.MarshalIndent(data, "", " ")
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filepath.Join(dir, fileName), jsonData, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // this code is to check if certain cases produce the correct errors (missing table etc)
 // this also indirectly tests if the keys are case-insensitive
-func TestGenericErrors(t *testing.T) {
+func TestNewInsertGenericErrors(t *testing.T) {
+	var err error
 	initForTest(t)
-	// check for missing table error
-	sampleTemplate = map[string]map[string]map[string]any{
-		"table": {
-			"column": {
-				"TYPE": "INT",
-				"CoDe": "RANDOM",
-			},
-		},
-	}
-	tempDir := t.TempDir()
-	tempFile, err := os.CreateTemp(tempDir, "") // create a temporary file
-	defer func(tempFile *os.File) {
-		err = tempFile.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(tempFile)
+	file, _ := getTempDirAndFile(t)
+	defer file.Close()
+	testCase, err = getTemplate(db, "irrelevant")
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write to temporary file
+	// path testing
+	testPath := "./"
+	// test no file specified
+	_, err = template.NewInsertTemplate(db, "template", "./")
+	if err == nil {
+		t.Fatalf("expected error since path '%s' doesn't specify file", testPath)
+	}
+
+	testPath = "some_file.md"
+	// test file doesn't exist
+	_, err = template.NewInsertTemplate(db, "template", testPath)
+	if err == nil {
+		t.Fatalf("expected error since file '%s' doesn't exist", testPath)
+	}
+
+	testPath = ""
+	// test empty string
+	_, err = template.NewInsertTemplate(db, "template", testPath)
+	if !errors.As(err, &template.MissingPathError{}) {
+		t.Fatal("expected error since this function does not allow empty path")
+	}
+
+	// valid path but invalid template (i.e. not map[string]map[string]map[string]any)
+	err = writeInvalidTemplateToFile(file.Name(), map[string]bool{"": true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name()) // see if we can make a template
+
+	_, err = template.NewInsertTemplate(db, "template", testPath)
+	if err == nil {
+		t.Fatalf("expected error since JSON template at '%s' is invalid", testPath)
+	}
+
+	// put a valid template in
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test table doesn't exist
+	tableName := "asfasfasfa"
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
 	if !errors.As(err, &graph.MissingTableError{}) {
-		t.Fatalf("expected MissingTableError, received %v", err)
+		t.Fatalf("expected error since the table '%s' does not exist", tableName)
 	}
 
-	sampleTemplate["template"] = sampleTemplate["table"] // change name by copying data to new valid key
-	delete(sampleTemplate, "table")                      // delete the key
-
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // overwrite file
+	tableName = "irrelevant"
+	// test missing table in template
+	testCase, err = getTemplate(db, "irrelevant")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name()) // run TemplateFrom again
-	if !errors.As(err, &graph.MissingColumnError{}) {
-		t.Fatalf("expected MissingColumnError, received %v", err)
-	}
-
-	sampleTemplate["template"]["uuid"] = sampleTemplate["template"]["column"] // change to a valid column
-	delete(sampleTemplate["template"], "column")                              // delete the key
-
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // overwrite file
+	delete(testCase, "template") // get rid of required table
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if !errors.As(err, &template.MissingRequiredTableError{}) {
+		t.Fatalf("expected error since the template is missing required table '%s' but received '%v'", "template", err)
+	}
 
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name()) // run template from
+	// test schema errors
+
+	// add an irrelevant key to schema to see if sign triggers
+	testCase, err = getTemplate(db, "irrelevant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCase["template"]["date"]["new stuff"] = "henlo"
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
 	if !errors.As(err, &template.SchemaError{}) {
-		t.Fatalf("expected schemaError, received %v", err)
+		t.Fatalf("expected error since there is an additional key '%s' in schema but received '%v'", "new stuff", err)
 	}
 
-	//add the final value to make it a proper schema
-	sampleTemplate["template"]["uuid"]["ValuE"] = any(6)
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate)
+	// add invalid type to schema
+	delete(testCase["template"]["date"], "new stuff")
+	testCase["template"]["date"]["code"] = 5
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
-	if !errors.As(err, &strategy.UnexpectedTypeError{}) {
-		t.Fatalf("expected unexpectedTypeError, received %v", err)
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if !errors.As(err, &template.SchemaError{}) {
+		t.Fatal("expected error since 'code' key is expected to be string but is 'int'")
 	}
+
+	// test invalid type
+	testCase, err = getTemplate(db, "irrelevant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	testCase["template"]["date"]["type"] = "INT"
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if !errors.As(err, &strategy.UnexpectedTypeError{}) {
+		t.Fatal("expected error since 'type' key's value is supposed to be 'DATE' but was 'INT'")
+	}
+
+	// missing required column
+	testCase, err = getTemplate(db, "irrelevant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	delete(testCase["template"], "date")
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if !errors.As(err, &template.MissingRequiredColumnError{}) {
+		t.Fatalf("expected error since the template at '%s' is missing required column '%s' for table '%s'", file.Name(), "date", "template")
+	}
+}
+
+func TestInsertTemplateCycles(t *testing.T) {
+	var err error
+	initForTest(t)
+	file, _ := getTempDirAndFile(t)
+	defer file.Close()
+	cycleTable := "cycletable"
+	testCase, err = getTemplate(db, "template")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// validation for required tables is done AFTER we get the path so it doesn't
+	// matter that the template doesn't match the table
+	_, err = template.NewInsertTemplate(db, cycleTable, file.Name())
+	if err == nil {
+		t.Fatal("expected error since 'cycletable' has a cycle in it's path")
+	}
+	_, err = template.NewDefaultInsertTemplate(db, cycleTable)
+	if err == nil {
+		t.Fatal("expected error since 'cycletable' has a cycle in it's path")
+	}
+
 }
 
 func TestTemplateWithRequiredTables(t *testing.T) {
+	var err error
 	initForTest(t)
-	sampleTemplate = map[string]map[string]map[string]any{
-		"template": {
-			"int": {
-				"TYPE":  "INT",
-				"CoDe":  "RANDOM",
-				"Value": []int{5, 20},
-			},
-		},
-		"irrelivant": {
-			"key": {
-				"TYPE":  "INT",
-				"CoDe":  "SERIAL",
-				"Value": nil,
-			},
-		},
-	}
-	tempDir := t.TempDir()
-	tempFile, err := os.CreateTemp(tempDir, "")
+	file, _ := getTempDirAndFile(t)
+	defer file.Close()
+	tableName := "IRRELEVANT"
+	testCase, err = getTemplate(db, tableName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func(tempFile *os.File) {
-		err = tempFile.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(tempFile)
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // overwrite file
+	// test missing table
+	delete(testCase, "template")
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// check if missing required table
-	_, err = template.NewInsertTemplate(tableData, []string{"template", "some table"}, tempFile.Name())
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
 	if !errors.As(err, &template.MissingRequiredTableError{}) {
-		t.Fatalf("expected MissingRequiredTableError, received %v", err)
+		t.Fatalf("expected error since the required table '%s' is missing but received: '%v'", "template", err)
 	}
 
-	tmpl, err := template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
+	testCase, err = getTemplate(db, tableName)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	p := tmpl.GetStrategyCodePair("irrelivant", "key")
-	if !p.IsEmpty() {
-		t.Fatal("table 'irrelivant' is supposed to be ignored as it has no relation to table 'template'")
-	}
-
-}
-
-// all override codes ignore values, this test confirms that behavior
-// this also applies to the NULL code which is a special code that behaves like an override for any column type
-// the usual checks should still run
-func TestOverrideCode(t *testing.T) {
-	initForTest(t)
-	// sample template with an override code
-	tempDir := t.TempDir()
-	tempFile, err := os.CreateTemp(tempDir, "") // create a temporary file
-	defer func(tempFile *os.File) {
-		err = tempFile.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(tempFile)
+	delete(testCase["template"], "date")
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
 	}
-	sampleTemplate = map[string]map[string]map[string]any{
-		"template": {
-			"date": {
-				"TYPE":  "DATE",
-				"CoDe":  "NOW",
-				"value": nil,
-			},
-		},
-	}
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name()) // shouldn't be an error
-	if err != nil {
-		t.Fatal(err)
-	}
-	sampleTemplate["template"]["date"]["CoDe"] = "NULL"
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
-	if err != nil {
-		t.Fatal(err)
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if !errors.As(err, &template.MissingRequiredColumnError{}) {
+		t.Fatalf("expected error since the table '%s' is missing required column '%s' but received: '%v'", "template", "date", err)
 	}
 }
 
-func TestOptionalCodes(t *testing.T) {
+func TestNewInsertTemplate_Codes(t *testing.T) {
+	var err error
 	initForTest(t)
-	var unsupportedErr strategy.UnexpectedTypeError
-	tempDir := t.TempDir()
-	tempFile, err := os.CreateTemp(tempDir, "")
+	file, _ := getTempDirAndFile(t)
+	defer file.Close()
+	tableName := "IRRELEVANT"
+	testCase, err = getTemplate(db, tableName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func(tempFile *os.File) {
-		err = tempFile.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(tempFile)
-
-	// valid case because default applies (nil value implies use default)
-	sampleTemplate = map[string]map[string]map[string]any{
-		"template": {
-			"int": {
-				"TYPE":  "INT",
-				"CoDe":  "SERIAL",
-				"value": nil,
-			},
-		},
-	}
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
+	// test invalid code
+	testCase["template"]["date"]["code"] = "NONEXISTENT"
+	testCase["template"]["date"]["value"] = nil
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
-	if err != nil {
-		t.Fatal(err)
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if !errors.As(err, &strategy.UnsupportedCodeError{}) {
+		t.Fatalf("code 'NONEXISTENT' is not defined for type 'DATE' but received '%v'", err)
 	}
 
-	// kinda redundant but in the future updates to preprocessing will allow both cases
-	// change val to valid case (int)
-	sampleTemplate["template"]["int"]["value"] = 6
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
+	// test valid code with invalid value
+	testCase["template"]["date"]["code"] = "RANDOM"
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
-	if err != nil {
-		t.Fatal(err)
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if err == nil {
+		t.Fatal("value 'nil' is not supported for code 'RANDOM', error should have been returned")
 	}
 
-	// change val to valid case (float 64)
-	sampleTemplate["template"]["int"]["value"] = 6.0
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
+	// test valid code with valid value
+	testCase, err = getTemplate(db, tableName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
+	testCase["template"]["int"]["code"] = "SERIAL"
+	err = utils.WriteInsertTemplateToFile(file.Name(), testCase)
 	if err != nil {
 		t.Fatal(err)
+	}
+	_, err = template.NewInsertTemplate(db, tableName, file.Name())
+	if err != nil {
+		t.Fatal("value 'nil' is supported for code 'SERIAL', error shouldn't have been returned")
 	}
 
-	// change val to invalid case (string)
-	sampleTemplate["template"]["int"]["value"] = ""
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
-	if !errors.As(err, &unsupportedErr) {
-		t.Fatalf("expected error of type UnexpectedTypeError, received %v", err)
-	}
 }
 
 func TestInsertTemplate_GetStrategy(t *testing.T) {
+	var err error
 	initForTest(t)
-	var tmpl *template.InsertTemplate
-	tempDir := t.TempDir()
-	tempFile, err := os.CreateTemp(tempDir, "")
+	file, _ := getTempDirAndFile(t)
+	defer file.Close()
+	tableName := "IRRELEVANT"
+	testCase, err = getTemplate(db, tableName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func(tempFile *os.File) {
-		err = tempFile.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(tempFile)
-
-	// valid case because default applies (nil value implies use default)
-	sampleTemplate = map[string]map[string]map[string]any{
-		"template": {
-			"int": {
-				"TYPE":  "INT",
-				"CoDe":  "SERIAL",
-				"value": nil,
-			},
-		},
-	}
-	err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
+	err = writeMapToJSONFile(file.Name(), testCase) // write data to file
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpl, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
+	tmpl, err := template.NewInsertTemplate(db, table, file.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -353,46 +398,4 @@ func TestInsertTemplate_GetStrategy(t *testing.T) {
 		t.Fatal("expected StrategyCodePair to be empty")
 	}
 
-}
-
-func TestInsertTemplateDefaults(t *testing.T) {
-	initForTest(t)
-	tempDir := t.TempDir()
-	tempFile, err := os.CreateTemp(tempDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func(tempFile *os.File) {
-		err = tempFile.Close()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}(tempFile)
-	sampleTemplate = map[string]map[string]map[string]any{
-		"template": {
-			"date": {
-				"TYPE":  "DATE",
-				"CoDe":  "NOW",
-				"value": nil,
-			},
-		},
-	}
-	supportedTypes := []string{"INT", "FLOAT", "UUID", "DATE", "BOOL", "VARCHAR"}
-	for _, supportedType := range supportedTypes {
-		sampleTemplate["template"] = map[string]map[string]any{
-			utils.TrimAndLowerString(supportedType): {
-				"type":  supportedType,
-				"code":  "",
-				"value": nil,
-			},
-		}
-		err = writeMapToJSONFile(tempFile.Name(), sampleTemplate) // write data to file
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = template.NewInsertTemplate(tableData, requiredTables, tempFile.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
 }

--- a/template/template.go
+++ b/template/template.go
@@ -4,7 +4,6 @@
 package template
 
 import (
-	"errors"
 	"fmt"
 	"github.com/Keith1039/dbvg/strategy"
 	"github.com/Keith1039/dbvg/utils"
@@ -25,15 +24,8 @@ func makeTypeMap(data map[string]any) map[string]string {
 
 // check if the type map matches the given schema
 func checkAgainstSchema(typeMap map[string]string, schema map[string]string) error {
-	var err error
-	if typeMap == nil || len(typeMap) != len(schema) {
-
-		if typeMap == nil {
-			err = errors.New("type map is nil")
-		} else {
-			err = SchemaError{expectedSchema: schema, actualSchema: typeMap}
-		}
-		return err
+	if len(typeMap) != len(schema) {
+		return SchemaError{expectedSchema: schema, actualSchema: typeMap}
 	} else {
 		for key, val := range typeMap {
 			// check the schema values but make an exception for any


### PR DESCRIPTION
This refactor is aimed at making the `template` package, namely the `InsertTemplate` code, easier to use. While the current method is optimal, it's a little odd to use for a user. This is because it assumes the user either reads docs or understands the code as well as I do. Neither is likely and so it has been simplified.

This causes some duplicated effort but ultimately, this way is better. Future changes will further optimize the code that utilizes this. At the moment though, this is functional

Other Changes:
- Edited code that uses the old design
- Fixed tests
- Added a new error type
- Fixed a bug where the code didn't check for all necessary columns
- New code to export defaults