### PR TITLE
Task 34.3: Improving Parameters Coverage

### DIFF
--- a/parameters/batch_test.go
+++ b/parameters/batch_test.go
@@ -21,6 +21,8 @@ import (
 
 var db *sql.DB
 
+var defaultAmount = 10
+
 var pgConf pgtestdb.Config
 
 var migrator pgtestdb.Migrator
@@ -31,11 +33,12 @@ func init() {
 	pgConf = pgtestdb.Config{
 		DriverName: "postgres", // uses the lib/pq driver
 		//Database:   "postgres",
-		User:     "postgres",
-		Password: "password",
-		Host:     "localhost",
-		Port:     "2000",
-		Options:  "sslmode=disable",
+		User:                      "postgres",
+		Password:                  "password",
+		Host:                      "localhost",
+		Port:                      "2000",
+		Options:                   "sslmode=disable",
+		ForceTerminateConnections: true,
 	}
 	migrator = golangmigrator.New(realMigrationDir)
 }
@@ -82,12 +85,12 @@ func TestQueryBatch_Exec(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	insertBatch, deleteBatch := batchWriter.GenerateEntries(500)
+	insertBatch, deleteBatch := batchWriter.GenerateEntries(defaultAmount)
 	err = insertBatch.Exec(db, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = checkCountForTable(db, "COMPANIES", 501)
+	err = checkCountForTable(db, "COMPANIES", defaultAmount+1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +136,7 @@ func TestQueryBatch_ExecRollback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	insertBatch, _ := batchWriter.GenerateEntries(500)
+	insertBatch, _ := batchWriter.GenerateEntries(defaultAmount)
 	err = insertBatch.Exec(db, false)
 	if err == nil {
 		t.Fatal("unique constraint should have been violated due to static code used for email field")
@@ -152,18 +155,103 @@ func TestQueryBatch_ExecRollback(t *testing.T) {
 func TestQueryBatch_ExecContext(t *testing.T) {
 	migrator = golangmigrator.New(realMigrationDir)
 	db = pgtestdb.New(t, pgConf, migrator)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
 		t.Fatal(err)
 	}
 	insertBatch, _ := batchWriter.GenerateEntries(5000)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	err = insertBatch.ExecContext(ctx, db, false)
 	if err == nil {
 		t.Fatal("should have timed out...")
 	}
 	err = checkCountForTable(db, "COMPANIES", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQueryBatch_ExecTransact(t *testing.T) {
+	// see if the function uses the same transaction
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertBatch, _ := batchWriter.GenerateEntries(defaultAmount)
+	err = insertBatch.ExecTransact(tx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tx.Rollback() // if it's part of the same transaction, table should be empty
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = checkCountForTable(db, "USERS", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestQueryBatch_ExecContextTransact(t *testing.T) {
+	migrator = golangmigrator.New(realMigrationDir)
+	pgConf.ForceTerminateConnections = true
+	db = pgtestdb.New(t, pgConf, migrator)
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertBatch, _ := batchWriter.GenerateEntries(5000)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	err = insertBatch.ExecTransactContext(ctx, tx, false)
+	if err == nil {
+		t.Fatal("should have timed out")
+	}
+
+	err = checkCountForTable(db, "USERS", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// see if this function still uses the same transaction
+	tx, err = db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx = context.Background()
+	err = insertBatch.ExecTransactContext(ctx, tx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx.Rollback()
+	err = checkCountForTable(db, "USERS", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestQueryBatch_Verbose(t *testing.T) {
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
+	batchWriter, err := parameters.NewQueryWriter(db, "purchases")
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertBatch, _ := batchWriter.GenerateEntry()
+	err = insertBatch.Exec(db, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +302,7 @@ func Benchmark_ExecInsert(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	insertBatch, deleteBatch := batchWriter.GenerateEntries(5000)
+	insertBatch, deleteBatch := batchWriter.GenerateEntries(500)
 	b.ResetTimer()
 	for range b.N {
 		b.StartTimer()
@@ -238,7 +326,7 @@ func Benchmark_ExecDelete(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	insertBatch, deleteBatch := batchWriter.GenerateEntries(5000)
+	insertBatch, deleteBatch := batchWriter.GenerateEntries(500)
 	b.ResetTimer()
 	for range b.N {
 		b.StopTimer()

--- a/parameters/query_writer.go
+++ b/parameters/query_writer.go
@@ -71,7 +71,7 @@ func (qw *QueryWriter) init() error {
 	if err != nil {
 		return err
 	}
-	return err
+	return nil
 }
 
 func (qw *QueryWriter) setFKMap() {

--- a/parameters/query_writer_test.go
+++ b/parameters/query_writer_test.go
@@ -1,6 +1,8 @@
 package parameters_test
 
 import (
+	"errors"
+	"github.com/Keith1039/dbvg/graph"
 	"github.com/Keith1039/dbvg/parameters"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	_ "github.com/lib/pq"
@@ -27,25 +29,50 @@ func TestNewQueryWriter_Generic(t *testing.T) {
 	migrator = golangmigrator.New(migrationDir + "case9")
 	db = pgtestdb.New(t, pgConf, migrator)
 	_, err := parameters.NewQueryWriter(db, "some_table")
-	if err == nil {
-		t.Fatal("table doesn't exist in schema, error should have occurred")
+	if !errors.As(err, &graph.MissingTableError{}) {
+		t.Fatalf("expected 'MissingTableError', got %v", err)
 	}
 	_, err = parameters.NewQueryWriter(db, "b")
+	if !errors.As(err, &graph.CyclicError{}) {
+		t.Fatalf("expected 'CyclicError', got %v", err)
+	}
+	_, err = parameters.NewQueryWriterWithTemplate(nil, "b", "some_path")
 	if err == nil {
-		t.Fatal("error should have occurred due to cycle in schema")
+		t.Fatal("error should have due to nil DB connection")
+	}
+	// path error
+	_, err = parameters.NewQueryWriterWithTemplate(db, "z", "some_path")
+	if err == nil {
+		t.Fatal("error should happen due to to non existent file at path ")
 	}
 }
 
 func TestQueryWriter_GenerateEntries(t *testing.T) {
 	migrator = golangmigrator.New(realMigrationDir)
 	db = pgtestdb.New(t, pgConf, migrator)
-	amount := 500
 	writer, err := parameters.NewQueryWriter(db, "purchases")
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedAmount := amount * len(writer.TableOrder)
-	insertBatch, deleteBatch := writer.GenerateEntries(amount)
+	expectedAmount := defaultAmount * len(writer.TableOrder)
+	insertBatch, deleteBatch := writer.GenerateEntries(defaultAmount)
+	if insertBatch.Size() != expectedAmount {
+		t.Fatalf("insertBatch.Size() returned %d instead of %d", insertBatch.Size(), expectedAmount)
+	}
+	if deleteBatch.Size() != expectedAmount {
+		t.Fatalf("deleteBatch.Size() returned %d instead of %d", deleteBatch.Size(), expectedAmount)
+	}
+}
+
+func TestQueryWriter_GenerateEntry(t *testing.T) {
+	migrator = golangmigrator.New(realMigrationDir)
+	db = pgtestdb.New(t, pgConf, migrator)
+	writer, err := parameters.NewQueryWriter(db, "purchases")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedAmount := len(writer.TableOrder)
+	insertBatch, deleteBatch := writer.GenerateEntry()
 	if insertBatch.Size() != expectedAmount {
 		t.Fatalf("insertBatch.Size() returned %d instead of %d", insertBatch.Size(), expectedAmount)
 	}
@@ -63,7 +90,7 @@ func BenchmarkGenerateQueries(b *testing.B) {
 	}
 	b.ResetTimer()
 	for range b.N {
-		insertBatch, deleteBatch := writer.GenerateEntries(5000)
+		insertBatch, deleteBatch := writer.GenerateEntries(500)
 		b.Logf("\ninsert batch size: %d\ndelete batch size: %d", insertBatch.Size(), deleteBatch.Size())
 	}
 	b.StopTimer()


### PR DESCRIPTION
This commit improves the test coverage for the `parameters` package. As always, no new functionality was created. Tests were either created or updated.

As a result of these changes, coverage was increased `87.2%` --> `97.2%`

The remaining `2.8%` is unreachable code that will be addressed in the future but not in this PR

Other changes:
- changed most tests to use a smaller default (10) instead of 500 to speed up tests there are exceptions however
- decreased amount generated for benchmarks: `5000` --> `500`
