### PR TITLE
Task 34.4: Improving db coverage & optimizing

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -80,16 +80,16 @@ func CloseDB(db *sql.DB) {
 	}
 }
 
-// GetTableMap returns a map of existing table names mapped to the number 1 in the given database
-func GetTableMap(db *sql.DB) map[string]int {
+// GetTableMap returns a map of existing table names mapped to true in the given database
+func GetTableMap(db *sql.DB) map[string]bool {
+	allNames := make(map[string]bool)
 	tnames, err := schema.TableNames(db)
-	allNames := make(map[string]int)
 	if err != nil {
 		log.Fatal(err)
 	}
 	for i := range tnames {
 		tableName := tnames[i][1]
-		allNames[tableName] = 1
+		allNames[tableName] = true
 	}
 	return allNames
 }
@@ -110,7 +110,6 @@ func GetColumnMap(db *sql.DB, tableName string) map[string]string {
 	tcols, err := schema.ColumnTypes(db, "", tableName) // get the column info
 	if err != nil {
 		log.Fatal(err)
-		return nil
 	}
 
 	for i := range tcols {

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -33,16 +33,44 @@ func init() {
 	}
 }
 
+func TestInitAndCloseDB(t *testing.T) {
+	// valid connection url
+	db2, err := database.InitDB(pgConf.URL())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.CloseDB(db2)
+	err = db2.Ping()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIsSupportedType(t *testing.T) {
+	ok := database.IsSupportedType("int")
+	if ok {
+		t.Fatal("lower case type name should be invalid")
+	}
+	ok = database.IsSupportedType("SOMERAndom")
+	if ok {
+		t.Fatal("unsupported type name should be invalid")
+	}
+	ok = database.IsSupportedType("VARCHAR")
+	if !ok {
+		t.Fatal("VARCHAR is a supported type but was deemed invalid")
+	}
+}
+
 func TestGetTableMap(t *testing.T) {
 	migrator = golangmigrator.New("migrations/case5")
 	db = pgtestdb.New(t, pgConf, migrator)
-	expectedMap := map[string]int{
-		"a": 1,
-		"b": 1,
-		"c": 1,
-		"d": 1,
-		"e": 1,
-		"f": 1,
+	expectedMap := map[string]bool{
+		"a": true,
+		"b": true,
+		"c": true,
+		"d": true,
+		"e": true,
+		"f": true,
 	}
 	data := database.GetTableMap(db)
 	delete(data, "schema_migrations")

--- a/graph/node.go
+++ b/graph/node.go
@@ -9,7 +9,7 @@ type topologicalNode struct {
 	completed     bool
 }
 
-func getTopologicalNodes(allTables map[string]int, allRelations map[string]map[string]map[string]string) map[string]*topologicalNode {
+func getTopologicalNodes(allTables map[string]bool, allRelations map[string]map[string]map[string]string) map[string]*topologicalNode {
 	m := make(map[string]*topologicalNode) // map of the table names tied to the node
 	for tableName := range allTables {
 		relations, exists := allRelations[tableName]

--- a/graph/ordering.go
+++ b/graph/ordering.go
@@ -29,7 +29,7 @@ func NewOrdering(db *sql.DB) (*Ordering, error) {
 // Ordering is a struct that contains the information necessary to detect and remove cycles
 type Ordering struct {
 	db           *sql.DB                                 // the database connection
-	allTables    map[string]int                          // a map of all the tables in the database
+	allTables    map[string]bool                         // a map of all the tables in the database
 	allRelations map[string]map[string]map[string]string // all table relationships in a mapped form
 	stack        *list.List                              // a stack
 }


### PR DESCRIPTION
This round of changes is aimed at improving the coverage of the `db` package. Surprisingly there wasn't much that could be covered. As such, alongside some new tests, a small size optimization was done with the `GetTableMap()` function. It now has a string mapped to a bool which is much smaller than the original int. What matters is the keys, not the value of the map so this change doesn't break anything. Code around this change needed to be adjusted however.

As a result of these changes, the coverage was improved from `77.2%` --> `83.5%`

The remaining `16.5%` consists of edge cases that result in `log.Fatal()` being called.