### PR TITLE
Task 34.6: Adding SVG badges and new workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -28,3 +28,11 @@ jobs:
       - name: Stop containers
         if: always()
         run: docker compose down
+
+      - name: Update coverage report
+        uses: ncruces/go-coverage-report@v0
+        with:
+          report: true
+          chart: true
+          amend: true
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DBVG (Work in progress)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Keith1039/dbvg.svg)](https://pkg.go.dev/github.com/Keith1039/dbvg)
+![Go Test](https://github.com/Keith1039/dbvg/actions/workflows/go-test.yml/badge.svg?event=push)
+[![Go Coverage](https://github.com/https://github.com/Keith1039/dbvg/wiki/coverage.svg)](https://raw.githack.com/wiki/Keith1039/dbvg/coverage.html)
 
 Database validator and generator (dbvg) for Postgres. Use as a CLI or import as a library.
 


### PR DESCRIPTION
This commit updates the `go-test.yaml` workflow to add to a coverage report when pushing on master. It also updates the README to having more SVG badges