### PR TITLE
Task 34.7 Ammend workflow

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -25,10 +25,6 @@ jobs:
       - name: Test with the Go CLI
         run: go test -v ./...
 
-      - name: Stop containers
-        if: always()
-        run: docker compose down
-
       - name: Update coverage report
         uses: ncruces/go-coverage-report@v0
         with:
@@ -36,3 +32,7 @@ jobs:
           chart: true
           amend: true
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down


### PR DESCRIPTION
Currently, the workflow fails due to the docker container closing early. This changes it to stop after the coverage report.