### PR TITLE
Task 36: Add versioning to CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,6 +30,8 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - -s -w -X github.com/Keith1039/dbvg/cmd.version={{.Version}}
 project_name: dbvg
 archives:
   - formats: ['tar.gz']

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2026 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "provides the version of the CLI",
+	Long:  `"provides the version of the CLI"`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("dbvg %s\n", version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.3
 
 require (
 	github.com/brianvoe/gofakeit/v7 v7.2.1
+	github.com/dromara/carbon/v2 v2.6.16
 	github.com/duktig-solutions/go-random-date-generator v0.0.0-20220823170630-1c67478b7653
 	github.com/golang-migrate/migrate/v4 v4.18.1
 	github.com/google/uuid v1.6.0
@@ -17,13 +18,11 @@ require (
 )
 
 require (
-	github.com/dromara/carbon/v2 v2.6.16 // indirect
 	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/smartystreets/goconvey v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 )


### PR DESCRIPTION
This adds the linker flags necessary to indicate the version of the CLI for release

Other Changes:
- Go mod changes